### PR TITLE
update to support concurrent state run and fixed sls names

### DIFF
--- a/states/orch/bootstrap/init.sls
+++ b/states/orch/bootstrap/init.sls
@@ -31,8 +31,9 @@
 {{ sls }} salt-prime minion bootstrap prep:
   salt.state:
     - tgt: {{ pillar.location.salt_prime_id }}
-    - sls: prime_prep
+    - sls: orch.bootstrap.prime_prep
     - saltenv: {{ saltenv }}
+    - concurrent: True
     - kwarg:
       pillar:
         tgt_pod: {{ POD }}
@@ -50,7 +51,7 @@
 {{ sls }} bootstrap minion:
   salt.state:
     - tgt: {{ MID }}
-    - sls: minion
+    - sls: orch.bootstrap.minion
     - saltenv: {{ saltenv }}
     - ssh: True
     - kwarg:
@@ -65,8 +66,9 @@
 {{ sls }} salt-prime minion bootstrap cleanup failure:
   salt.state:
     - tgt: {{ pillar.location.salt_prime_id }}
-    - sls: prime_cleanup_failure
+    - sls: orch.bootstrap.prime_cleanup_failure
     - saltenv: {{ saltenv }}
+    - concurrent: True
     - kwarg:
       pillar:
         tgt_mid: {{ MID }}
@@ -80,12 +82,15 @@
 {{ sls }} salt-prime minion bootstrap cleanup success:
   salt.state:
     - tgt: {{ pillar.location.salt_prime_id }}
-    - sls: prime_cleanup_success
+    - sls: orch.bootstrap.prime_cleanup_success
     - saltenv: {{ saltenv }}
+    - concurrent: True
     - kwarg:
       pillar:
         tgt_mid: {{ MID }}
         tgt_ip: {{ IP }}
         tgt_tmp: {{ TMP }}
+    - require:
+      - salt: {{ sls }} bootstrap minion
     - onlyif:
       - test -d {{ TMP }}


### PR DESCRIPTION
## Description
Update to support concurrent state run and fixed sls names (I failed to fully test bootstrap in [move shared bootstrap code into bootstrap/init.sls by TimidRobot · Pull Request #10](https://github.com/creativecommons/sre-salt-prime/pull/10)).

## Other information
- > **concurrent**
   >    Allow multiple state runs to occur at once.
   >    WARNING: This flag is potentially dangerous. It is designed for use when multiple state runs can safely be run at the same Do not use this flag for performance optimization.
  > ([salt.states.saltmod.state](https://docs.saltstack.com/en/latest/ref/states/all/salt.states.saltmod.html#salt.states.saltmod.state))
- [Concurrent and Queued SaltStack State Runs | Ryan D Lane](https://blog.ryandlane.com/2014/09/02/concurrent-and-queued-saltstack-state-runs/)


## Checklist
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `master` branch of the repository.
- [x] My commit messages follow [best practices][best_practices].
- [ ] I added tests for the changes I made (if applicable).
- N/A I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

<!-- Make sure you read and understand the following attestation. -->
## Developer Certificate of Origin
```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```
