### PR TITLE
correct debian_ami_id to use us-east-2 id instead of us-west-2 id

### DIFF
--- a/pillars/infra/us-east-2/init.sls
+++ b/pillars/infra/us-east-2/init.sls
@@ -2,14 +2,14 @@ infra:
   us-east-2:
     # url: https://wiki.debian.org/Cloud/AmazonEC2Image/Buster
     debian_ami_name: debian-10-amd64-20191117-80
-    debian_ami_id: ami-018774bc9055cf127
+    debian_ami_id: ami-05d9978d11a05da49
     instance_iam_role: ec2_core_iam_role
     kms_key_id_storage: storage_core_kmskey
     vendor: aws
     region: us-east-2
     salt_prime: 10.22.11.11
-    # cmd: aws --region us-east-2 ec2 describe-vpcs
     vpc:
+      # cmd: aws --region us-east-2 ec2 describe-vpcs
       name: us-east-2_core_vpc
       id: vpc-04cea7e4be82901e9
       cidr: 10.22.0.0/16


### PR DESCRIPTION
## Description
correct `debian_ami_id` to use us-east-2 id instead of us-west-2 id (https://wiki.debian.org/Cloud/AmazonEC2Image/Buster)

## Checklist
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `master` branch of the repository.
- [x] My commit messages follow [best practices][best_practices].
- [ ] I added tests for the changes I made (if applicable).
- N/A I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

<!-- Make sure you read and understand the following attestation. -->
## Developer Certificate of Origin
```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```
