### PR TITLE
Add label to filesystem and use it for mount

### DIFF
--- a/pillars/3_HST/salt-prime.sls
+++ b/pillars/3_HST/salt-prime.sls
@@ -7,9 +7,17 @@ include:
 
 location:
   salt_prime_ip: 127.0.0.1
+mounts:
+  - spec: /dev/nvme1n1
+    file: /srv
+    type: ext4
+    opts: defaults
+    freq: 0
+    pass: 2
 salt:
   gitfs_remotes:
     - git@github.com:creativecommons/mysql-formula.git
     - git@github.com:creativecommons/php-formula.git
 states:
+  mount: {{ sls }}
   wikijs.reports: {{ sls }}

--- a/states/mount/init.sls
+++ b/states/mount/init.sls
@@ -1,17 +1,29 @@
-{% for mount in pillar.mounts -%}
-{{ sls }} format {{ mount.type }}:
+{%- for mount in pillar.mounts -%}
+{%- set label = mount.file.replace("/", "-").strip("-") %}
+{{ sls }} format {{ mount.spec }} as {{ mount.type }}:
   blockdev.formatted:
     - name: {{ mount.spec }}
     - fs_type: {{ mount.type }}
 
 
+{{ sls }} label {{ mount.spec }} as {{ label }}:
+  cmd.run:
+    - name: e2label {{ mount.spec }} {{ label }}
+    - onchanges:
+      - blockdev: {{ sls }} format {{ mount.spec }} as {{ mount.type }}
+
+
 {{ sls }} mount {{ mount.file }}:
   mount.mounted:
     - name: {{ mount.file }}
-    - device: {{ mount.spec }}
+    - device: LABEL={{ label }}
     - fstype: {{ mount.type }}
     - mkmnt: True
     - opts: {{ mount.opts }}
     - dump: {{ mount.freq }}
     - pass_num: {{ mount.pass }}
+    - match_on: name
+    - require:
+      - blockdev: {{ sls }} format {{ mount.spec }} as {{ mount.type }}
+      - cmd: {{ sls }} label {{ mount.spec }} as {{ label }}
 {% endfor -%}


### PR DESCRIPTION
## Description
1. Add mount configuration for salt-prime
2. Updated to add label to new filesystem and use it for mount

## Other information
This partially addresses the accurate and appropriate concerns raised in https://github.com/creativecommons/sre-salt-prime/pull/20#pullrequestreview-342502492.

It does **not** ensure the device is accurate, but it **will** result in a kinder softer error state instead of potentially resulting in an unbootable host.

It has been applied to all hosts (by commenting out `onchanges` lines 12-13).

## Checklist
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `master` branch of the repository.
- [x] My commit messages follow [best practices][best_practices].
- [ ] I added tests for the changes I made (if applicable).
- N/A I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

<!-- Make sure you read and understand the following attestation. -->
## Developer Certificate of Origin
```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```
