### PR TITLE
ccEngine mount and state order fixes

### DIFF
--- a/pillars/3_HST/ccengine.sls
+++ b/pillars/3_HST/ccengine.sls
@@ -2,7 +2,7 @@ ccengine:
   # set the default here (may be overridden by subsequent sls)
   branch: master
 mounts:
-  - spec: /dev/nvme1n1
+  - spec: /dev/nvme0n1
     file: /srv
     type: ext4
     opts: defaults

--- a/states/ccengine/env.sls
+++ b/states/ccengine/env.sls
@@ -10,6 +10,7 @@ include:
     - name: /srv/ccengine/env
     - require:
       - file: ccengine /srv/ccengine
+      - pkg: ccengine installed packages
 
 
 {{ sls }} env setup:
@@ -28,6 +29,7 @@ include:
     - bin_env: /srv/ccengine/env
     - require:
       - git: ccengine.src rdfadict repo
+      - virtualenv: {{ sls }} env setup
     - unless:
       - test -f {{ SITE_PACKAGES }}/rdfadict.egg-link
 
@@ -39,6 +41,7 @@ include:
     - bin_env: /srv/ccengine/env
     - require:
       - git: ccengine.src cc.i18n repo
+      - virtualenv: {{ sls }} env setup
     - unless:
       - test -f {{ SITE_PACKAGES }}/cc.i18n.egg-link
 


### PR DESCRIPTION
## Description
1. Corrected mount spec (mount handling itself is improved in https://github.com/creativecommons/sre-salt-prime/pull/27)
2. Improve order of operations of `ccengine.env` via require requisite ([Requisites and Other Global State Arguments][requisites])

[requisites]: https://docs.saltstack.com/en/latest/ref/states/requisites.html

## Checklist
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `master` branch of the repository.
- [x] My commit messages follow [best practices][best_practices].
- [ ] I added tests for the changes I made (if applicable).
- N/A I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

<!-- Make sure you read and understand the following attestation. -->
## Developer Certificate of Origin
```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```
