### PR TITLE
Add custom NGINX logs

### DIFF
--- a/pillars/3_HST/dispatch.sls
+++ b/pillars/3_HST/dispatch.sls
@@ -7,5 +7,14 @@ letsencrypt:
     restart_nginx.sh: /usr/sbin/service nginx reload
 states:
   nginx.dispatch: {{ sls }}
+  mount: {{ sls }}
+mounts:
+  - spec: /dev/nvme1n1
+    file: /srv
+    type: ext4
+    opts: defaults
+    freq: 0
+    pass: 2
 nginx:
   flavor: light
+  custom_log_dir: /srv/log-nginx-custom

--- a/pillars/infra/ec2_instance_web.sls
+++ b/pillars/infra/ec2_instance_web.sls
@@ -18,7 +18,7 @@ infra:
       # Specific (please maintain order)
       ccengine: 214
       chapters: 334
-      dispatch: ABSENT
+      dispatch: 214
       openglam: 214
       sotc: 214
       summit: 214

--- a/states/logrotate/files/nginx_custom_logs
+++ b/states/logrotate/files/nginx_custom_logs
@@ -1,0 +1,43 @@
+# Managed by SaltStack: {{ SLS }}
+
+
+{{ LOG_DIR }}/access_archive*.log {
+	daily
+	missingok
+	# 1825 days is 5 years
+	rotate 1825
+	dateext
+	compress
+	delaycompress
+	notifempty
+	create 0640 www-data adm
+	sharedscripts
+	prerotate
+		if [ -d /etc/logrotate.d/httpd-prerotate ]; then \
+			run-parts /etc/logrotate.d/httpd-prerotate; \
+		fi \
+	endscript
+	postrotate
+		invoke-rc.d nginx rotate >/dev/null 2>&1
+	endscript
+}
+
+
+{{ LOG_DIR }}/access_debug*.log {
+	daily
+	missingok
+	rotate 7
+	compress
+	delaycompress
+	notifempty
+	create 0640 www-data adm
+	sharedscripts
+	prerotate
+		if [ -d /etc/logrotate.d/httpd-prerotate ]; then \
+			run-parts /etc/logrotate.d/httpd-prerotate; \
+		fi \
+	endscript
+	postrotate
+		invoke-rc.d nginx rotate >/dev/null 2>&1
+	endscript
+}

--- a/states/logrotate/nginx_custom_logs.sls
+++ b/states/logrotate/nginx_custom_logs.sls
@@ -1,0 +1,9 @@
+{{ sls }} nginx_custom_logs:
+  file.managed:
+    - name: /etc/logrotate.d/nginx_custom_logs
+    - source: salt://logrotate/files/nginx_custom_logs
+    - mode: '0444'
+    - template: jinja
+    - defaults:
+        SLS: {{ sls }}
+        LOG_DIR: {{ pillar.nginx.custom_log_dir }}

--- a/states/nginx/custom_log_formats.sls
+++ b/states/nginx/custom_log_formats.sls
@@ -1,0 +1,32 @@
+{% import "nginx/jinja2.sls" as nginx with context -%}
+{% set CONFS_INSTALL = ["custom_log_formats", "real_ip_from_cloudflare"] -%}
+{% set NOW = None|strftime("%Y%m%d_%H%M%S") -%}
+
+
+include:
+  - logrotate.nginx_custom_logs
+
+
+{{ sls }} custom log dir:
+  file.directory:
+    - name: {{ pillar.nginx.custom_log_dir }}
+    - group: adm
+{%- if pillar.mounts %}
+    - require:
+{%- for mount in pillar.mounts %}
+      - mount: mount mount {{ mount.file }}
+{%- endfor %}
+{%- endif %}
+
+
+{{ sls }} /var/log symlink:
+  file.symlink:
+    - name: /var/log/nginx-custom
+    - target: {{ pillar.nginx.custom_log_dir }}
+    - force: True
+    - backupname: /var/log/nginx-custom.{{ NOW }}
+    - require:
+      - file: {{ sls }} custom log dir
+
+
+{{ nginx.install_confs(sls, CONFS_INSTALL) -}}

--- a/states/nginx/dispatch.sls
+++ b/states/nginx/dispatch.sls
@@ -4,6 +4,7 @@
 
 include:
   - nginx
+  - nginx.custom_log_formats
   - letsencrypt
 
 
@@ -18,6 +19,7 @@ include:
         SLS: {{ sls }}
     - require:
       - pkg: nginx installed packages
+      - file: nginx.custom_log_formats install conf custom_log_formats
     - watch_in:
       - service: nginx service
 

--- a/states/nginx/files/custom_log_formats.conf
+++ b/states/nginx/files/custom_log_formats.conf
@@ -1,9 +1,9 @@
 # Managed by SaltStack: {{ SLS }}
 
 
-# Long term historical log with privacy
-# Based on https://stackoverflow.com/posts/45405406/revisions
+# JSON formatted long term archive access log with privacy
 
+# Based on https://stackoverflow.com/posts/45405406/revisions
 map $remote_addr $remote_addr_anon {
     ~(?P<ip>\d+\.\d+\.\d+)\.    $ip.0;
     ^(?P<ip>[^:]+(?::[^:]+)?):  $ip::;
@@ -22,11 +22,11 @@ log_format json_archive escape=json
     '}';
 
 
-# Short term troubleshooting log
+# JSON formatted short term debug access log
 #
 # This log format includes two time formats:
 # 1. time_iso8601 for human parsing and time zone information
-# 2. msec for for machine parsing and millesonds resolution
+# 2. msec for machine parsing and millesonds resolution
 
 log_format json_debug escape=json
     '{'

--- a/states/nginx/files/custom_log_formats.conf
+++ b/states/nginx/files/custom_log_formats.conf
@@ -1,0 +1,57 @@
+# Managed by SaltStack: {{ SLS }}
+
+
+# Long term historical log with privacy
+# Based on https://stackoverflow.com/posts/45405406/revisions
+
+map $remote_addr $remote_addr_anon {
+    ~(?P<ip>\d+\.\d+\.\d+)\.    $ip.0;
+    ^(?P<ip>[^:]+(?::[^:]+)?):  $ip::;
+    default                     0.0.0.0;
+}
+
+log_format json_archive escape=json
+    '{'
+        '"time_iso8601":"$time_iso8601", '
+        '"remote_addr_anon":"$remote_addr_anon", '
+        '"request_method":"$request_method", '
+        '"request_uri":"$request_uri", '
+        '"status":"$status", '
+        '"http_referer":"$http_referer", '
+        '"http_user_agent":"$http_user_agent"'
+    '}';
+
+
+# Short term troubleshooting log
+#
+# This log format includes two time formats:
+# 1. time_iso8601 for human parsing and time zone information
+# 2. msec for for machine parsing and millesonds resolution
+
+log_format json_debug escape=json
+    '{'
+        '"time_iso8601":"$time_iso8601", '
+        '"msec":"$msec", '
+        # Request
+        '"request_time":"$request_time", '
+        '"request_method":"$request_method", '
+        '"request_uri":"$request_uri", '
+        '"status":"$status", '
+        '"body_bytes_sent":"$body_bytes_sent", '
+        '"http_referer":"$http_referer", '
+        # Backend
+        '"proxy_host":"$proxy_host", '
+        '"proxy_port":"$proxy_port", '
+        '"upstream_http_server":"$upstream_http_server", '
+        '"upstream_connect_time":"$upstream_connect_time", '
+        '"upstream_header_time":"$upstream_header_time", '
+        '"upstream_response_time":"$upstream_response_time", '
+        # Cache
+        '"realip_remote_addr":"$realip_remote_addr", '
+        # Client
+        '"remote_addr":"$remote_addr", '
+        '"http_user_agent":"$http_user_agent"'
+    '}';
+
+
+# vim: ft=nginx:

--- a/states/nginx/files/dispatch_basic_template
+++ b/states/nginx/files/dispatch_basic_template
@@ -1,4 +1,3 @@
-# vim: ft=nginx:
 # Managed by SaltStack: {{ SLS }}
 
 
@@ -6,7 +5,8 @@ server {
     listen 80;
     listen [::]:80;
     server_name {{ CERT_NAME }};
-    access_log off;
+    access_log {{ pillar.nginx.custom_log_dir }}/access_debug.log
+        json_debug buffer=32k flush=2s;
     # Enable letsencrypt authorization
     location /.well-known {
         default_type "text/plain";
@@ -30,3 +30,6 @@ server {
         return 503;
     }
 }
+
+
+# vim: ft=nginx:

--- a/states/nginx/files/dispatch_tls_template
+++ b/states/nginx/files/dispatch_tls_template
@@ -1,4 +1,3 @@
-# vim: ft=nginx:
 # Managed by SaltStack: {{ SLS }}
 
 
@@ -6,7 +5,10 @@ server {
     listen 443 ssl http2;
     listen [::]:443 ssl http2;
     server_name {{ CERT_NAME }};
-    access_log off;
+    access_log {{ pillar.nginx.custom_log_dir }}/access_archive.log
+        json_archive buffer=32k flush=2s;
+    access_log {{ pillar.nginx.custom_log_dir }}/access_debug.log
+        json_debug buffer=32k flush=2s;
     ssl_certificate /etc/letsencrypt/live/{{ CERT_NAME }}/fullchain.pem;
     ssl_certificate_key /etc/letsencrypt/live/{{ CERT_NAME }}/privkey.pem;
     # NGINX Docs | NGINX Reverse Proxy
@@ -21,3 +23,6 @@ server {
     }
 {%- endfor %}
 }
+
+
+# vim: ft=nginx:

--- a/states/nginx/files/real_ip_from_cloudflare.conf
+++ b/states/nginx/files/real_ip_from_cloudflare.conf
@@ -1,0 +1,42 @@
+# Managed by SaltStack: {{ SLS }}
+#
+# To update this file, run the updated_cloudlfare_ips.sh scripton Salt-Prime
+# and then deploy via SaltStack
+
+
+# Restoring original visitor IPs: Logging visitor IP addresses with
+# mod_cloudflare – Cloudflare Support
+# https://support.cloudflare.com/hc/en-us/articles/200170786-Restoring-original-visitor-IPs-Logging-visitor-IP-addresses-with-mod-cloudflare-
+
+
+# https://www.cloudflare.com/ips-v4
+set_real_ip_from 103.21.244.0/22;
+set_real_ip_from 103.22.200.0/22;
+set_real_ip_from 103.31.4.0/22;
+set_real_ip_from 104.16.0.0/12;
+set_real_ip_from 108.162.192.0/18;
+set_real_ip_from 131.0.72.0/22;
+set_real_ip_from 141.101.64.0/18;
+set_real_ip_from 162.158.0.0/15;
+set_real_ip_from 172.64.0.0/13;
+set_real_ip_from 173.245.48.0/20;
+set_real_ip_from 188.114.96.0/20;
+set_real_ip_from 190.93.240.0/20;
+set_real_ip_from 197.234.240.0/22;
+set_real_ip_from 198.41.128.0/17;
+
+
+# https://www.cloudflare.com/ips-v6
+set_real_ip_from 2400:cb00::/32;
+set_real_ip_from 2405:8100::/32;
+set_real_ip_from 2405:b500::/32;
+set_real_ip_from 2606:4700::/32;
+set_real_ip_from 2803:f800::/32;
+set_real_ip_from 2a06:98c0::/29;
+set_real_ip_from 2c0f:f248::/32;
+
+
+real_ip_header X-Forwarded-For;
+
+
+# vim: ft=nginx:

--- a/states/nginx/files/real_ip_from_cloudflare.conf
+++ b/states/nginx/files/real_ip_from_cloudflare.conf
@@ -1,6 +1,6 @@
 # Managed by SaltStack: {{ SLS }}
 #
-# To update this file, run the updated_cloudlfare_ips.sh scripton Salt-Prime
+# To update this file, run the updated_cloudlfare_ips.sh script on Salt-Prime
 # and then deploy via SaltStack
 
 

--- a/states/nginx/files/updated_cloudlfare_ips.sh
+++ b/states/nginx/files/updated_cloudlfare_ips.sh
@@ -19,7 +19,7 @@ IPV6="$(curl --http2 --raw --silent https://www.cloudflare.com/ips-v6 \
     echo '# Managed by SaltStack: {{ SLS }}'
     echo '#'
     printf '# To update this file, run the updated_cloudlfare_ips.sh script'
-    printf 'on Salt-Prime\n# and then deploy via SaltStack\n'
+    printf ' on Salt-Prime\n# and then deploy via SaltStack\n'
     echo
     echo
     echo '# Restoring original visitor IPs: Logging visitor IP addresses with'

--- a/states/nginx/files/updated_cloudlfare_ips.sh
+++ b/states/nginx/files/updated_cloudlfare_ips.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+set -o errexit
+set -o errtrace
+set -o nounset
+
+trap '_es=${?};
+    printf "${0}: line ${LINENO}: \"${BASH_COMMAND}\"";
+    printf " exited with a status of ${_es}\n";
+    exit ${_es}' ERR
+
+IPV4="$(curl --http2 --raw --silent https://www.cloudflare.com/ips-v4 \
+         | sort -V)"
+IPV6="$(curl --http2 --raw --silent https://www.cloudflare.com/ips-v6 \
+        | ipv6calc --addr_to_fulluncompressed \
+        | sort \
+        | ipv6calc --addr_to_compressed)"
+
+{
+    echo '# Managed by SaltStack: {{ SLS }}'
+    echo '#'
+    printf '# To update this file, run the updated_cloudlfare_ips.sh script'
+    printf 'on Salt-Prime\n# and then deploy via SaltStack\n'
+    echo
+    echo
+    echo '# Restoring original visitor IPs: Logging visitor IP addresses with'
+    echo '# mod_cloudflare – Cloudflare Support'
+    printf '# https://support.cloudflare.com/hc/en-us/articles/'
+    printf '200170786-Restoring-original-visitor-IPs-Logging-visitor-IP-'
+    printf 'addresses-with-mod-cloudflare-\n'
+    echo
+    echo
+    echo '# https://www.cloudflare.com/ips-v4'
+    for _ip in ${IPV4}
+    do
+        echo "set_real_ip_from ${_ip};"
+    done
+    echo
+    echo
+    echo '# https://www.cloudflare.com/ips-v6'
+    for _ip in ${IPV6}
+    do
+        echo "set_real_ip_from ${_ip};"
+    done
+    echo
+    echo
+    echo 'real_ip_header X-Forwarded-For;'
+    echo
+    echo
+    echo '# vim: ft=nginx:'
+} > real_ip_from_cloudflare.conf
+
+# vim: ft=sh:

--- a/states/nginx/files/updated_cloudlfare_ips.sh
+++ b/states/nginx/files/updated_cloudlfare_ips.sh
@@ -15,38 +15,36 @@ IPV6="$(curl --http2 --raw --silent https://www.cloudflare.com/ips-v6 \
         | sort \
         | ipv6calc --addr_to_compressed)"
 
-{
-    echo '# Managed by SaltStack: {{ SLS }}'
-    echo '#'
-    printf '# To update this file, run the updated_cloudlfare_ips.sh script'
-    printf ' on Salt-Prime\n# and then deploy via SaltStack\n'
-    echo
-    echo
-    echo '# Restoring original visitor IPs: Logging visitor IP addresses with'
-    echo '# mod_cloudflare – Cloudflare Support'
-    printf '# https://support.cloudflare.com/hc/en-us/articles/'
-    printf '200170786-Restoring-original-visitor-IPs-Logging-visitor-IP-'
-    printf 'addresses-with-mod-cloudflare-\n'
-    echo
-    echo
-    echo '# https://www.cloudflare.com/ips-v4'
-    for _ip in ${IPV4}
+cat << HEREDOC > real_ip_from_cloudflare.conf
+# Managed by SaltStack: {{ SLS }}
+#
+# To update this file, run the updated_cloudlfare_ips.sh script on Salt-Prime
+# and then deploy via SaltStack
+
+
+# Restoring original visitor IPs: Logging visitor IP addresses with
+# mod_cloudflare – Cloudflare Support
+# https://support.cloudflare.com/hc/en-us/articles/200170786-Restoring-original-visitor-IPs-Logging-visitor-IP-addresses-with-mod-cloudflare-
+
+
+# https://www.cloudflare.com/ips-v4
+$(  for _ip in ${IPV4}
     do
         echo "set_real_ip_from ${_ip};"
-    done
-    echo
-    echo
-    echo '# https://www.cloudflare.com/ips-v6'
-    for _ip in ${IPV6}
+    done)
+
+
+# https://www.cloudflare.com/ips-v6
+$(  for _ip in ${IPV6}
     do
         echo "set_real_ip_from ${_ip};"
-    done
-    echo
-    echo
-    echo 'real_ip_header X-Forwarded-For;'
-    echo
-    echo
-    echo '# vim: ft=nginx:'
-} > real_ip_from_cloudflare.conf
+    done)
+
+
+real_ip_header X-Forwarded-For;
+
+
+# vim: ft=nginx:
+HEREDOC
 
 # vim: ft=sh:

--- a/states/nginx/jinja2.sls
+++ b/states/nginx/jinja2.sls
@@ -6,6 +6,9 @@
     - name: /etc/nginx/conf.d/{{ conf }}.conf
     - source: salt://nginx/files/{{ conf }}.conf
     - mode: '0444'
+    - template: jinja
+    - defaults:
+        SLS: {{ sls }}
     - require:
       - pkg: nginx installed packages
     - watch_in:


### PR DESCRIPTION
<!-- Please replace #XX below with an existing issue number. Remove the line entirely if none exist. -->
Fixes #31

## Description
This add two custom NGINX  access logs:
1. JSON formatted long term archive access log with privacy (`access_archive.log`)
    - rotated daily for 5 years
    - truncates last part of IP to preserve user privacy (`remote_addr_anon`)
2. JSON formatted short term debug access log (`access_debug.log`)
   - rotated daily for 7 days
   - includes full client IP (`remote_addr`)
   - also includes and Cloudflare IP (`realip_remote_addr`)

This PR also includes support for setting the real client IP (instead of the Cloudflare IP) and a script to allow us to update the Cloudflare IPs.

Please also evaluate the decisions made. For example:
- Should archive log have more or less info?
- Should archive logs be kept for a shorter or longer time period?
- Should debug log have more or less info?
- Should debug logs be kept for a shorter or longer time period?
- Should user agent be kept in full?
- JSON?

## Other information

#### `access_archive.log`
Entry example:
```json
{"time_iso8601":"2020-02-27T21:16:49+00:00", "remote_addr_anon":"104.35.248.0", "request_method":"GET", "request_uri":"/licenses/by/4.0/?1582838209", "status":"200", "http_referer":"", "http_user_agent":"HTTPie/0.9.4"}
```
Formatted/linted:
```json
{
  "time_iso8601": "2020-02-27T21:16:49+00:00",
  "remote_addr_anon": "104.35.248.0",
  "request_method": "GET",
  "request_uri": "/licenses/by/4.0/?1582838209",
  "status": "200",
  "http_referer": "",
  "http_user_agent": "HTTPie/0.9.4"
}
```

#### `access_debug.log`
```json
{"time_iso8601":"2020-02-27T21:16:49+00:00", "msec":"1582838209.620", "request_time":"0.011", "request_method":"GET", "request_uri":"/licenses/by/4.0/?1582838209", "status":"200", "body_bytes_sent":"10944", "http_referer":"", "proxy_host":"10.22.11.12", "proxy_port":"80", "upstream_http_server":"Apache", "upstream_connect_time":"0.000", "upstream_header_time":"0.008", "upstream_response_time":"0.008", "realip_remote_addr":"172.69.33.45", "remote_addr":"[REDACTED]", "http_user_agent":"HTTPie/0.9.4"}
```
Formatted/linted:
```json
{
  "time_iso8601": "2020-02-27T21:16:49+00:00",
  "msec": "1582838209.620",
  "request_time": "0.011",
  "request_method": "GET",
  "request_uri": "/licenses/by/4.0/?1582838209",
  "status": "200",
  "body_bytes_sent": "10944",
  "http_referer": "",
  "proxy_host": "10.22.11.12",
  "proxy_port": "80",
  "upstream_http_server": "Apache",
  "upstream_connect_time": "0.000",
  "upstream_header_time": "0.008",
  "upstream_response_time": "0.008",
  "realip_remote_addr": "172.69.33.45",
  "remote_addr": "[REDACTED]",
  "http_user_agent": "HTTPie/0.9.4"
}
```

## Checklist
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `master` branch of the repository.
- [x] My commit messages follow [best practices][best_practices].
- [ ] I added tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

<!-- Make sure you read and understand the following attestation. -->
## Developer Certificate of Origin
```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```
