### PR TITLE
Configure ccEngine

### DIFF
--- a/pillars/5_HST__POD/ccengine__stage.sls
+++ b/pillars/5_HST__POD/ccengine__stage.sls
@@ -2,3 +2,5 @@ apache2:
   server_name: ccengine-stage
 ccengine:
   branch: dev2019
+  cc_cache: false
+  fcgid_max_procs: 3

--- a/states/apache2/files/ccengine.conf
+++ b/states/apache2/files/ccengine.conf
@@ -2,6 +2,7 @@
 
 
 # https://httpd.apache.org/mod_fcgid/mod/mod_fcgid.html
+FcgidIOTimeout 30
 FcgidMaxProcesses {{ pillar.ccengine.fcgid_max_procs }}
 
 
@@ -44,10 +45,6 @@ FcgidMaxProcesses {{ pillar.ccengine.fcgid_max_procs }}
         DirectoryIndex deed
     </Location>
 
-    <LocationMatch "/(deed|legalcode|rdf)">
-        Header set Cache-Control "public, max-age=1800"
-    </LocationMatch>
-
     # Always serve up deeds as text/html, even when the country code
     # extension makes Apache think it's something else, like .pl being
     # a perl script instead of Poland, but not if it's a CSS file.
@@ -55,10 +52,10 @@ FcgidMaxProcesses {{ pillar.ccengine.fcgid_max_procs }}
         ForceType text/html
     </LocationMatch>
 
+    # Allow all ccEngine content to be cached for 30 minutes
+    Header set Cache-Control "public, max-age=1800"
     # CloudFlare does not like Accept-Ranges
     Header set Accept-Ranges none
-
-    FcgidIOTimeout 30
 
     RewriteEngine on
 

--- a/states/apache2/files/ccengine.conf
+++ b/states/apache2/files/ccengine.conf
@@ -1,4 +1,10 @@
 # Managed by SaltStack: {{ SLS }}
+
+
+# https://httpd.apache.org/mod_fcgid/mod/mod_fcgid.html
+FcgidMaxProcesses {{ pillar.ccengine.fcgid_max_procs }}
+
+
 <VirtualHost *:80>
     ServerName {{ SERVER_NAME }}
     ErrorLog ${APACHE_LOG_DIR}/{{ SERVER_NAME }}_error.log
@@ -37,6 +43,10 @@
         DefaultType text/html
         DirectoryIndex deed
     </Location>
+
+    <LocationMatch "/(deed|legalcode|rdf)">
+        Header set Cache-Control "public, max-age=1800"
+    </LocationMatch>
 
     # Always serve up deeds as text/html, even when the country code
     # extension makes Apache think it's something else, like .pl being
@@ -170,8 +180,7 @@
     # Deeds (CC Engine): mitigation via REDIRECT
     RewriteRule ^/licenses/publicdomain/[0-9]\.[0-9](.*)$  /licenses/publicdomain/$1 [L,R=301]
 
-{%- if pillar.pod == "prod" %}
-{#- Caching is enabled in production #}
+{%- if pillar.ccengine.cc_cache %}
     # Deeds (CC Engine): pull from CACHE
     # See if deed is cached before sending to cc.engine
     RewriteCond %{REQUEST_URI} ^/licenses/

--- a/states/ccengine/files/config.ini
+++ b/states/ccengine/files/config.ini
@@ -7,7 +7,7 @@ direct_remote_paths =
    includes /includes/
 
 [pipeline:main]
-{%- if pillar.pod == "prod" %}
+{%- if pillar.ccengine.cc_cache %}
 # Caching is enabled in production
 pipeline = errors cache ccengine
 {%- else %}


### PR DESCRIPTION
## Description
Improves configurability of the ccEngine to better allow different configs in different environments and better support performance testing

## Checklist
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `master` branch of the repository.
- [x] My commit messages follow [best practices][best_practices].
- [ ] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

<!-- Make sure you read and understand the following attestation. -->
## Developer Certificate of Origin
```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```
