### PR TITLE
Better NVMEe handling within Debian AWS EC2 Instances

### DIFF
--- a/pillars/3_HST/biztool.sls
+++ b/pillars/3_HST/biztool.sls
@@ -9,7 +9,7 @@ letsencrypt:
   post_hooks:
     restart_apache2.sh: /usr/sbin/service apache2 reload
 mounts:
-  - spec: /dev/nvme1n1
+  - spec: /dev/xvdf
     file: /var/www
     type: ext4
     opts: defaults

--- a/pillars/3_HST/ccengine.sls
+++ b/pillars/3_HST/ccengine.sls
@@ -2,7 +2,7 @@ ccengine:
   # set the default here (may be overridden by subsequent sls)
   branch: master
 mounts:
-  - spec: /dev/nvme0n1
+  - spec: /dev/xvdf
     file: /srv
     type: ext4
     opts: defaults

--- a/pillars/3_HST/chapters.sls
+++ b/pillars/3_HST/chapters.sls
@@ -9,7 +9,7 @@ letsencrypt:
   post_hooks:
     apache2_reload.sh: /usr/sbin/service apache2 reload
 mounts:
-  - spec: /dev/nvme1n1
+  - spec: /dev/xvdf
     file: /var/www
     type: ext4
     opts: defaults

--- a/pillars/3_HST/discourse.sls
+++ b/pillars/3_HST/discourse.sls
@@ -4,7 +4,7 @@ states:
   discourse: {{ sls }}
   mount: {{ sls }}
 mounts:
-  - spec: /dev/nvme1n1
+  - spec: /dev/xvdf
     file: /srv
     type: ext4
     opts: defaults

--- a/pillars/3_HST/dispatch.sls
+++ b/pillars/3_HST/dispatch.sls
@@ -9,7 +9,7 @@ states:
   nginx.dispatch: {{ sls }}
   mount: {{ sls }}
 mounts:
-  - spec: /dev/nvme1n1
+  - spec: /dev/xvdf
     file: /srv
     type: ext4
     opts: defaults

--- a/pillars/3_HST/openglam.sls
+++ b/pillars/3_HST/openglam.sls
@@ -9,7 +9,7 @@ letsencrypt:
   post_hooks:
     restart_apache2.sh: /usr/sbin/service apache2 reload
 mounts:
-  - spec: /dev/nvme1n1
+  - spec: /dev/xvdf
     file: /var/www
     type: ext4
     opts: defaults

--- a/pillars/3_HST/podcast.sls
+++ b/pillars/3_HST/podcast.sls
@@ -9,7 +9,7 @@ letsencrypt:
   post_hooks:
     restart_apache2.sh: /usr/sbin/service apache2 reload
 mounts:
-  - spec: /dev/nvme1n1
+  - spec: /dev/xvdf
     file: /var/www
     type: ext4
     opts: defaults

--- a/pillars/3_HST/salt-prime.sls
+++ b/pillars/3_HST/salt-prime.sls
@@ -8,7 +8,7 @@ include:
 location:
   salt_prime_ip: 127.0.0.1
 mounts:
-  - spec: /dev/nvme1n1
+  - spec: /dev/xvdf
     file: /srv
     type: ext4
     opts: defaults

--- a/pillars/3_HST/sotc.sls
+++ b/pillars/3_HST/sotc.sls
@@ -9,7 +9,7 @@ letsencrypt:
   post_hooks:
     restart_apache2.sh: /usr/sbin/service apache2 reload
 mounts:
-  - spec: /dev/nvme1n1
+  - spec: /dev/xvdf
     file: /var/www
     type: ext4
     opts: defaults

--- a/pillars/3_HST/summit.sls
+++ b/pillars/3_HST/summit.sls
@@ -9,7 +9,7 @@ letsencrypt:
   post_hooks:
     restart_apache2.sh: /usr/sbin/service apache2 reload
 mounts:
-  - spec: /dev/nvme1n1
+  - spec: /dev/xvdf
     file: /var/www
     type: ext4
     opts: defaults

--- a/states/common/init.sls
+++ b/states/common/init.sls
@@ -1,7 +1,9 @@
-{% if grains['virtual'] == 'kvm' %}
+{%- if grains.virtual == "kvm" %}
 include:
   - .virtual
-{% endif %}
+
+
+{% endif -%}
 
 
 {{ sls }} installed packages:
@@ -10,6 +12,7 @@ include:
       - apt-transport-https
       - dnsutils
       - htop
+      - nvme-cli
       - python-apt
       - rsync
       - silversearcher-ag

--- a/states/common/init.sls
+++ b/states/common/init.sls
@@ -1,9 +1,7 @@
 {%- if grains.virtual == "kvm" %}
 include:
   - .virtual
-
-
-{% endif -%}
+{%- endif %}
 
 
 {{ sls }} installed packages:

--- a/states/mount/init.sls
+++ b/states/mount/init.sls
@@ -12,8 +12,6 @@
           if nvme id-ctrl -v ${n} | grep -q '^0000:.*{{ spec_short }}'
           then
             ln -s ${n} {{ spec_long }}
-          else
-            continue
           fi
         done
     - require:


### PR DESCRIPTION
Fixes #43

## Description

Updated to:
1. install `nvme-cli` package
2. use `nvme` command to detect which `/dev/nvme?n?` contains *spec* (ex. `xvdf`) in the NVMe vendor specific data
3. create a symlink (ex. `/dev/xvdf -> /dev/nvme1n1`) so that SaltStack can use `/dev/xvdf` for setup
4. delete symlink since there is no guarantee it will be accurate on subsequent reboots

## Other information
I opted to not create a custom grain since the device identification/mapping only needs to happen once. After that the filesystem is mounted by label.

## Checklist
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `master` branch of the repository.
- [x] My commit messages follow [best practices][best_practices].
- [ ] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

<!-- Make sure you read and understand the following attestation. -->
## Developer Certificate of Origin
```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```
