### PR TITLE
Use host variable in dispatcher and remove host pillar for misc

### DIFF
--- a/pillars/5_HST__POD/dispatch__prod.sls
+++ b/pillars/5_HST__POD/dispatch__prod.sls
@@ -37,11 +37,9 @@ nginx:
     - description: Miscellaneous
       location: /faq
       server: {{ SERVER_MISC }}
-      host: creativecommons.org
     - description: Miscellaneous
       location: /platform/toolkit
       server: {{ SERVER_MISC }}
-      host: creativecommons.org
     # Default (WordPress)
     - description: Default (WordPress)
       location: /

--- a/states/nginx/files/dispatch_tls_template
+++ b/states/nginx/files/dispatch_tls_template
@@ -23,7 +23,7 @@ server {
     location {{ dispatch.location }} {
         proxy_buffering off;
         proxy_pass {{ dispatch.server }}$request_uri;
-        proxy_set_header Host      $host;
+        proxy_set_header Host      {{ host }};
         proxy_set_header X-Real-IP $remote_addr;
     }
 {%- endfor %}


### PR DESCRIPTION
## Description
• Updated to use the Jinja2 variable that is set. Without it, the proxied host forced a redirect.
• Removed host value for misc as it is not needed.

## Technical details
Currently, the new not-yet-but-almost production dispatcher serves the new ccEngine, legacy WordPress, and legacy Misc.

## Tests
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete the section entirely. -->

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `master` branch of the repository.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
