### PR TITLE
disabled salt.proxy and added note about iptables

### DIFF
--- a/pillars/6_ID/bastion__core__us-east-2.sls
+++ b/pillars/6_ID/bastion__core__us-east-2.sls
@@ -1,2 +1,4 @@
+{# There are currently no external SaltStack minions that require proxy access
 states:
   salt.proxy: {{ sls }}
+#}

--- a/states/salt/proxy.sls
+++ b/states/salt/proxy.sls
@@ -1,3 +1,8 @@
+# NOTE: It may be better to manage iptables per:
+#         Managing IPtables efficiently with Saltstack - Server Fault
+#         https://serverfault.com/a/948526
+
+
 # Configure proxy host (it should have a static public IP) to forward SaltStack
 # traffic to salt prime host
 {% set PROXY_IP = pillar.location.salt_proxy_ip -%}


### PR DESCRIPTION
## Description
Disabled the `salt.proxy` state for the bastion host (and manually removed the configuration from the host and removed the AWS Security Group from the instance).

This was a premature optimization. We do not currently  have any external SaltStack minions that require proxy access. This meant we had extra cost (increased attack surface) without any benefit.

I also added a note for potential improvements to iptables management in case we enable this again in the future.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `master` branch of the repository.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
