### PR TITLE
updated docroot and redirects to better manage RDF and related HTML

### DIFF
--- a/states/apache2/files/ccengine.conf
+++ b/states/apache2/files/ccengine.conf
@@ -158,8 +158,11 @@ FcgidMaxProcesses {{ pillar.ccengine.fcgid_max_procs }}
 
 
     # RDF (static XML)
-    RewriteRule ^/(publicdomain|licenses)/(.*)/([0-9]\.[0-9])/rdf$  /rdf/creativecommons.org_$1_$2_$3_.rdf [L,T=application/rdf+xml]
-    RewriteRule ^/licenses/publicdomain/rdf$                        /rdf/creativecommons.org_licenses_publicdomain_.rdf [L,T=application/rdf+xml]
+    RewriteRule ^/(publicdomain|licenses)/(.*)/([0-9]\.[0-9])/rdf$  /rdf-licenses/creativecommons.org_$1_$2_$3_.rdf [L,T=application/rdf+xml]
+    RewriteRule ^/licenses/publicdomain/rdf$                        /rdf-licenses/creativecommons.org_licenses_publicdomain_.rdf [L,T=application/rdf+xml]
+    RewriteRule ^/licenses/index.rdf$                               /rdf-meta/index.rdf [L,T=application/rdf+xml]
+    # RDF related (static HTML)
+    RewriteRule ^/ns$  /rdf-meta/ns.html
 
 
     # Chooser (CC Engine): REDIRECT specified invalid URLs to Chooser

--- a/states/ccengine/docroot.sls
+++ b/states/ccengine/docroot.sls
@@ -24,24 +24,6 @@ include:
 {%- endfor %}
 
 
-{{ sls }} dir licenses:
-  file.directory:
-    - name: /srv/ccengine/docroot/licenses
-    - require:
-      - file: {{ sls }} /srv/ccengine/docroot
-
-
-{{ sls }} symlink index.rdf:
-  file.symlink:
-    - name: /srv/ccengine/docroot/licenses/index.rdf
-    - target: /srv/ccengine/src/cc.licenserdf/cc/licenserdf/rdf/index.rdf
-    - require:
-      - file: {{ sls }} dir licenses
-      - git: ccengine.src cc.licenserdf repo
-    - require_in:
-      - test: ccengine completed
-
-
 {{ sls }} dir ns:
   file.directory:
     - name: /srv/ccengine/docroot/ns
@@ -52,7 +34,7 @@ include:
 {{ sls }} symlink ns.html:
   file.symlink:
     - name: /srv/ccengine/docroot/ns/index.html
-    - target: /srv/ccengine/src/cc.licenserdf/cc/licenserdf/rdf/ns.html
+    - target: ../rdf-meta/ns.html
     - require:
       - file: {{ sls }} dir ns
       - git: ccengine.src cc.licenserdf repo
@@ -60,10 +42,21 @@ include:
       - test: ccengine completed
 
 
-{{ sls }} symlink rdf licenses:
+{{ sls }} symlink rdf-licenses:
   file.symlink:
-    - name: /srv/ccengine/docroot/rdf
+    - name: /srv/ccengine/docroot/rdf-licenses
     - target: /srv/ccengine/src/cc.licenserdf/cc/licenserdf/licenses
+    - require:
+      - file: {{ sls }} /srv/ccengine/docroot
+      - git: ccengine.src cc.licenserdf repo
+    - require_in:
+      - test: ccengine completed
+
+
+{{ sls }} symlink rdf-meta:
+  file.symlink:
+    - name: /srv/ccengine/docroot/rdf-meta
+    - target: /srv/ccengine/src/cc.licenserdf/cc/licenserdf/rdf
     - require:
       - file: {{ sls }} /srv/ccengine/docroot
       - git: ccengine.src cc.licenserdf repo
@@ -74,7 +67,7 @@ include:
 {{ sls }} symlink schema.rdf:
   file.symlink:
     - name: /srv/ccengine/docroot/schema.rdf
-    - target: /srv/ccengine/src/cc.licenserdf/cc/licenserdf/rdf/schema.rdf
+    - target: rdf-meta/schema.rdf
     - require:
       - file: {{ sls }} /srv/ccengine/docroot
       - git: ccengine.src cc.licenserdf repo


### PR DESCRIPTION
## Fixes
Fixes https://github.com/creativecommons/creativecommons.org/issues/1099

## Description
updated docroot and redirects to better manage RDF and related HTML

## Tests
Production:
```
for u in '/ns' '/ns/' '/licenses/index.rdf' '/schema.rdf' '/licenses/by/4.0/rdf' '/publicdomain/zero/1.0/rdf'
do https -h https://creativecommons.org${u}; done
```
Staging:
```
for u in '/ns' '/ns/' '/licenses/index.rdf' '/schema.rdf' '/licenses/by/4.0/rdf' '/publicdomain/zero/1.0/rdf'
do http -h https://stage.creativecommons.org${u}; done
```

## Docroot comparison
Production:
```
.
├── icons -> /srv/ccengine/src/creativecommons.org/docroot/icons
├── images -> /srv/ccengine/src/creativecommons.org/docroot/images
├── includes -> /srv/ccengine/src/creativecommons.org/docroot/includes
├── legalcode -> /srv/ccengine/src/creativecommons.org/docroot/legalcode
├── licenses
│   └── index.rdf -> /srv/ccengine/src/cc.licenserdf/cc/licenserdf/rdf/index.rdf
├── ns
│   └── index.html -> /srv/ccengine/src/cc.licenserdf/cc/licenserdf/rdf/ns.html
├── rdf -> /srv/ccengine/src/cc.licenserdf/cc/licenserdf/licenses
└── schema.rdf -> /srv/ccengine/src/cc.licenserdf/cc/licenserdf/rdf/schema.rdf

7 directories, 3 files
```
Staging:
```
.
├── icons -> /srv/ccengine/src/creativecommons.org/docroot/icons
├── images -> /srv/ccengine/src/creativecommons.org/docroot/images
├── includes -> /srv/ccengine/src/creativecommons.org/docroot/includes
├── legalcode -> /srv/ccengine/src/creativecommons.org/docroot/legalcode
├── ns
│   └── index.html -> ../rdf-meta/ns.html
├── rdf-licenses -> /srv/ccengine/src/cc.licenserdf/cc/licenserdf/licenses
├── rdf-meta -> /srv/ccengine/src/cc.licenserdf/cc/licenserdf/rdf
└── schema.rdf -> rdf-meta/schema.rdf

7 directories, 2 files
```


## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `master` branch of the repository.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
