### PR TITLE
Improved WebDev permissions

### DIFF
--- a/pillars/all/init.sls
+++ b/pillars/all/init.sls
@@ -7,3 +7,8 @@ states:
   swapfile: {{ sls }}
   user: {{ sls }}
   vim: {{ sls }}
+# Groups
+# 9.2.2. UID and GID classes - 9. The Operating System - Debian Policy Manual
+# https://www.debian.org/doc/debian-policy/ch-opersys.html#uid-and-gid-classes
+groups:
+  webdev: 4000

--- a/states/apache2/files/wordpress_composer.conf
+++ b/states/apache2/files/wordpress_composer.conf
@@ -19,13 +19,59 @@
     </Directory>
     <Directory {{ DOCROOT }}/wp-content/uploads>
         AllowOverride None
-        <FilesMatch "[.]ph(?:p[345]?|t|tml)$">
+        <FilesMatch "[.]ph(?:p\d?|t|tml)$">
             Require all denied
         </FilesMatch>
     </Directory>
     <FilesMatch "^[.]?wp-config[.]php">
         Require all denied
     </FilesMatch>
+
+    # Plugin Restrictions: Admin Menu Editor
+    <Directory {{ DOCROOT }}/wp-content/plugins/admin-menu-editor/includes>
+        Require all denied
+    </Directory>
+
+    # Plugin Restrictions: Akismet
+    <Directory {{ DOCROOT }}/wp-content/plugins/akismet>
+        Require all denied
+        # Akismet CSS and JS
+        <FilesMatch "^(form\.js|akismet\.js|akismet\.css)$">
+            Require all granted
+        </FilesMatch>
+        # Akismet images
+        <FilesMatch "^logo-full-2x\.png$">
+            Require all granted
+        </FilesMatch>
+    </Directory>
+    <Directory {{ DOCROOT }}/wp-content/vendor/johnpbloch/wordpress-core/wp-content/plugins/akismet>
+        Require all denied
+        # Akismet CSS and JS
+        <FilesMatch "^(form\.js|akismet\.js|akismet\.css)$">
+            Require all granted
+        </FilesMatch>
+        # Akismet images
+        <FilesMatch "^logo-full-2x\.png$">
+            Require all granted
+        </FilesMatch>
+    </Directory>
+
+    # Plugin Restrictions: Wordfence
+    <Directory {{ DOCROOT }}/wp-content/plugins/wordfence>
+        <FilesMatch "^(index|wordfence).php$">
+            Require all granted
+        </FilesMatch>
+        <FilesMatch "[.]ph(?:p\d?|t|tml)$">
+            Require all denied
+        </FilesMatch>
+    </Directory>
+    <Directory {{ DOCROOT }}/wp-content/plugins/wordfence/tmp>
+        Require all denied
+    </Directory>
+    <Directory {{ DOCROOT }}/wp-content/wflogs>
+        Require all denied
+    </Directory>
+
     SSLEngine on
     SSLCertificateFile {{ LE_CERT_PATH }}/fullchain.pem
     SSLCertificateKeyFile {{ LE_CERT_PATH }}/privkey.pem

--- a/states/apache2/init.sls
+++ b/states/apache2/init.sls
@@ -20,28 +20,32 @@
 {%- endif %}
 
 
+# If you edit this stanze, also edit the same stanza in states/nginx/init.sls
+{% set admins = salt["pillar.get"]("user:admins", {}).keys()|sort -%}
+{% set webdevs = salt["pillar.get"]("user:webdevs", {}).keys()|sort -%}
+{% set users = admins + webdevs|sort -%}
 {{ sls }} www-data group:
   group.present:
     - name: www-data
     - gid: 33
-{%- set admins = salt["pillar.get"]("user:admins", false) %}
-{%- set webdevs = salt["pillar.get"]("user:webdevs", false) %}
-{%- if admins or webdevs %}
+{%- if users %}
     - addusers:
-{%- if admins %}
-{%- for user in admins.keys() %}
-      - {{ user }}
+{%- for username in users %}
+      - {{ username }}
 {%- endfor %}
-{%- endif %}
-{%- if webdevs %}
-{%- for user in webdevs.keys() %}
-      - {{ user }}
-{%- endfor %}
-{%- endif %}
 {%- endif %}
     - require:
       - pkg: {{ sls }} installed packages
-
+{%- if admins %}
+{%- for username in admins %}
+      - user: user.admins {{ username }} user
+{%- endfor %}
+{%- endif %}
+{%- if webdevs %}
+{%- for username in webdevs %}
+      - user: user.webdevs {{ username }} user
+{%- endfor %}
+{%- endif %}
 
 
 {{ sls }} service:

--- a/states/nginx/init.sls
+++ b/states/nginx/init.sls
@@ -18,6 +18,29 @@ include:
       - file: tls dhparams.pem
 
 
+{{ sls }} www-data group:
+  group.present:
+    - name: www-data
+    - gid: 33
+{%- set admins = salt["pillar.get"]("user:admins", false) %}
+{%- set webdevs = salt["pillar.get"]("user:webdevs", false) %}
+{%- if admins or webdevs %}
+    - addusers:
+{%- if admins %}
+{%- for user in admins.keys() %}
+      - {{ user }}
+{%- endfor %}
+{%- endif %}
+{%- if webdevs %}
+{%- for user in webdevs.keys() %}
+      - {{ user }}
+{%- endfor %}
+{%- endif %}
+{%- endif %}
+    - require:
+      - pkg: {{ sls }} installed packages
+
+
 {{ sls }} service:
   service.running:
     - name: nginx

--- a/states/nginx/init.sls
+++ b/states/nginx/init.sls
@@ -18,27 +18,32 @@ include:
       - file: tls dhparams.pem
 
 
+# If you edit this stanze, also edit the same stanza in states/apache2/init.sls
+{% set admins = salt["pillar.get"]("user:admins", {}).keys()|sort -%}
+{% set webdevs = salt["pillar.get"]("user:webdevs", {}).keys()|sort -%}
+{% set users = admins + webdevs|sort -%}
 {{ sls }} www-data group:
   group.present:
     - name: www-data
     - gid: 33
-{%- set admins = salt["pillar.get"]("user:admins", false) %}
-{%- set webdevs = salt["pillar.get"]("user:webdevs", false) %}
-{%- if admins or webdevs %}
+{%- if users %}
     - addusers:
-{%- if admins %}
-{%- for user in admins.keys() %}
-      - {{ user }}
+{%- for username in users %}
+      - {{ username }}
 {%- endfor %}
-{%- endif %}
-{%- if webdevs %}
-{%- for user in webdevs.keys() %}
-      - {{ user }}
-{%- endfor %}
-{%- endif %}
 {%- endif %}
     - require:
       - pkg: {{ sls }} installed packages
+{%- if admins %}
+{%- for username in admins %}
+      - user: user.admins {{ username }} user
+{%- endfor %}
+{%- endif %}
+{%- if webdevs %}
+{%- for username in webdevs %}
+      - user: user.webdevs {{ username }} user
+{%- endfor %}
+{%- endif %}
 
 
 {{ sls }} service:

--- a/states/php_cc/composer.sls
+++ b/states/php_cc/composer.sls
@@ -1,43 +1,18 @@
-# - Members of user:webdevs are added to the composer Linux system group
-# - Members of user:admins are added to the composer Linux system group
 include:
   - php.composer
-
-
-{{ sls }} group:
-  group.present:
-    - name: composer
-    - system: True
-{%- set admins = salt["pillar.get"]("user:admins", false) %}
-{%- set webdevs = salt["pillar.get"]("user:webdevs", false) %}
-{%- if admins or webdevs %}
-    - addusers:
-{%- if admins %}
-{%- for user in admins.keys() %}
-      - {{ user }}
-{%- endfor %}
-{%- endif %}
-{%- if webdevs %}
-{%- for user in webdevs.keys() %}
-      - {{ user }}
-{%- endfor %}
-{%- endif %}
-{%- endif %}
-    - require_in:
-      - file: {{ sls }} config.json
+  - user.webdevs
 
 
 {{ sls }} user:
   user.present:
     - name: composer
+    - gid: 4000
     - home: /opt/composer
-    - gid_from_name: True
-    - createhome: False
     - password: '*'
     - shell: /usr/sbin/nologin
     - system: True
     - require:
-      - group: {{ sls }} group
+      - group: user.webdevs webdev group
     - require_in:
       - file: {{ sls }} config.json
 
@@ -47,7 +22,7 @@ include:
     - name: /opt/composer
     - mode: '0775'
     - user: composer
-    - group: composer
+    - group: webdev
     - require:
       - user: {{ sls }} user
 
@@ -66,7 +41,7 @@ include:
   file.directory:
     - name: /opt/composer/archive
     - mode: '2775'
-    - group: composer
+    - group: webdev
     - require:
       - file: {{ sls }} home
     - require_in:
@@ -77,7 +52,7 @@ include:
   file.directory:
     - name: /opt/composer/cache
     - mode: '2775'
-    - group: composer
+    - group: webdev
     - require:
       - file: {{ sls }} home
     - require_in:
@@ -88,7 +63,7 @@ include:
   file.directory:
     - name: /opt/composer/data
     - mode: '2775'
-    - group: composer
+    - group: webdev
     - require:
       - file: {{ sls }} dir cache
     - require_in:

--- a/states/php_cc/composer.sls
+++ b/states/php_cc/composer.sls
@@ -6,7 +6,7 @@ include:
 {{ sls }} user:
   user.present:
     - name: composer
-    - gid: 4000
+    - gid: {{ pillar.groups.webdev }}
     - home: /opt/composer
     - password: '*'
     - shell: /usr/sbin/nologin

--- a/states/sudo/files/webdev
+++ b/states/sudo/files/webdev
@@ -1,0 +1,7 @@
+# vim: ft=sudoers
+#
+# This file MUST be edited with `/usr/sbin/visudo -sf FILENAME`.
+
+Cmnd_Alias NORM_WP_PERMS = /usr/local/sbin/norm_wp_perms.sh
+
+%webdev ALL = NORM_WP_PERMS

--- a/states/sudo/files/webdev
+++ b/states/sudo/files/webdev
@@ -4,4 +4,4 @@
 
 Cmnd_Alias NORM_WP_PERMS = /usr/local/sbin/norm_wp_perms.sh
 
-%webdev ALL = NORM_WP_PERMS
+%webdev ALL = NOPASSWD: NORM_WP_PERMS

--- a/states/sudo/webdev.sls
+++ b/states/sudo/webdev.sls
@@ -1,0 +1,14 @@
+include:
+  - sudo
+
+
+{{ sls }} add webdev:
+  file.managed:
+    - name: /etc/sudoers.d/webdev
+    - source: salt://sudo/files/webdev
+    - mode: '0440'
+    - require:
+      - group: user.webdevs webdev group
+      - pkg: sudo installed packages
+    # Reminder: file.managed check_cmd is different than requisite check_cmd
+    - check_cmd: /usr/sbin/visudo -csf

--- a/states/user/admins.sls
+++ b/states/user/admins.sls
@@ -1,3 +1,8 @@
+# Also see the www-data group stanza in:
+# - states/apache2/init.sls
+# - states/nginx/init.sls
+
+
 {% set admins = pillar.user.admins.keys()|sort %}
 {% for username in admins -%}
 {% set userdata = pillar["user"]["admins"][username] -%}

--- a/states/user/admins.sls
+++ b/states/user/admins.sls
@@ -1,4 +1,5 @@
-{% for username in pillar.user.admins.keys() -%}
+{% set admins = pillar.user.admins.keys()|sort %}
+{% for username in admins -%}
 {% set userdata = pillar["user"]["admins"][username] -%}
 {{ sls }} {{ username }} group:
   group.present:
@@ -49,18 +50,20 @@
 {% endfor -%}
 {% endif -%}
 {% endfor -%}
-{% for group in pillar.user.admin_groups -%}
+
+
+{% for group in pillar.user.admin_groups|sort -%}
 {{ sls }} {{ group }} group:
   group.present:
     - name: {{ group }}
     - system: True
     - addusers:
-{%- for admin in pillar.user.admins.keys() %}
-      - {{ admin }}
+{%- for username in admins %}
+      - {{ username }}
 {%- endfor %}
     - require:
-{%- for admin in pillar.user.admins.keys() %}
-      - user: {{ sls }} {{ admin }} user
+{%- for username in admins %}
+      - user: {{ sls }} {{ username }} user
 {%- endfor %}
 
 

--- a/states/user/webdevs.sls
+++ b/states/user/webdevs.sls
@@ -1,4 +1,4 @@
-{%- for username in pillar.user.webdevs.keys() %}
+{%- for username in pillar.user.webdevs.keys()|sort %}
 {%- set userdata = pillar["user"]["webdevs"][username] %}
 {{ sls }} {{ username }} group:
   group.present:
@@ -69,25 +69,25 @@
 {% endfor -%}
 
 
+{% set admins = salt["pillar.get"]("user:admins", {}).keys()|sort -%}
+{% set webdevs = salt["pillar.get"]("user:webdevs", {}).keys()|sort -%}
+{% set users = admins + webdevs|sort -%}
 {{ sls }} webdev group:
   group.present:
     - name: webdev
     - gid: {{ pillar.groups.webdev }}
-{%- set admins = salt["pillar.get"]("user:admins", {}).keys() %}
-{%- set webdevs = salt["pillar.get"]("user:webdevs", {}).keys() %}
-{%- set users = admins + webdevs|sort %}
     - addusers:
-{%- for user in users %}
-      - {{ user }}
+{%- for username in users %}
+      - {{ username }}
 {%- endfor %}
     - require:
 {%- if admins %}
-{%- for user in admins %}
-      - user: user.admins {{ user }} user
+{%- for username in admins %}
+      - user: user.admins {{ username }} user
 {%- endfor %}
 {%- endif %}
 {%- if webdevs %}
-{%- for user in webdevs %}
-      - {{ user }}
+{%- for username in webdevs %}
+      - user: {{ sls }} {{ username }} user
 {%- endfor %}
 {%- endif %}

--- a/states/user/webdevs.sls
+++ b/states/user/webdevs.sls
@@ -67,3 +67,27 @@
 
 
 {% endfor -%}
+
+
+{{ sls }} webdev group:
+  group.present:
+    - name: webdev
+    - gid: {{ pillar.groups.webdev }}
+{%- set admins = salt["pillar.get"]("user:admins", {}).keys() %}
+{%- set webdevs = salt["pillar.get"]("user:webdevs", {}).keys() %}
+{%- set users = admins + webdevs|sort %}
+    - addusers:
+{%- for user in users %}
+      - {{ user }}
+{%- endfor %}
+    - require:
+{%- if admins %}
+{%- for user in admins %}
+      - user: user.admins {{ user }} user
+{%- endfor %}
+{%- endif %}
+{%- if webdevs %}
+{%- for user in webdevs %}
+      - {{ user }}
+{%- endfor %}
+{%- endif %}

--- a/states/user/webdevs.sls
+++ b/states/user/webdevs.sls
@@ -1,3 +1,8 @@
+# Also see the www-data group stanza in:
+# - states/apache2/init.sls
+# - states/nginx/init.sls
+
+
 {%- for username in pillar.user.webdevs.keys()|sort %}
 {%- set userdata = pillar["user"]["webdevs"][username] %}
 {{ sls }} {{ username }} group:

--- a/states/user/webdevs.sls
+++ b/states/user/webdevs.sls
@@ -3,7 +3,15 @@
 # - states/nginx/init.sls
 
 
-{%- for username in pillar.user.webdevs.keys()|sort %}
+include:
+  - sudo.webdev
+
+
+{% set admins = salt["pillar.get"]("user:admins", {}).keys()|sort -%}
+{% set webdevs = salt["pillar.get"]("user:webdevs", {}).keys()|sort -%}
+
+
+{%- for username in webdevs %}
 {%- set userdata = pillar["user"]["webdevs"][username] %}
 {{ sls }} {{ username }} group:
   group.present:
@@ -74,8 +82,6 @@
 {% endfor -%}
 
 
-{% set admins = salt["pillar.get"]("user:admins", {}).keys()|sort -%}
-{% set webdevs = salt["pillar.get"]("user:webdevs", {}).keys()|sort -%}
 {% set users = admins + webdevs|sort -%}
 {{ sls }} webdev group:
   group.present:

--- a/states/wordpress/backup.sls
+++ b/states/wordpress/backup.sls
@@ -5,10 +5,10 @@
   file.directory:
     - name: {{ DOCROOT }}/backup
     - mode: '2770'
-    - group: composer
+    - group: webdev
     - require:
       - file: wordpress.composer_site docroot
-      - user: php_cc.composer user
+      - group: user.webdevs webdev group
 
 
 {{ sls }} backup script:

--- a/states/wordpress/backup.sls
+++ b/states/wordpress/backup.sls
@@ -1,3 +1,7 @@
+# WARNINGS:
+# - If you updated the user/group within this file, be sure to also update the
+#   states/wordpress/files/norm_wp_perms.sh script
+#
 {% set DOCROOT = pillar.wordpress.docroot -%}
 
 

--- a/states/wordpress/composer_site.sls
+++ b/states/wordpress/composer_site.sls
@@ -31,8 +31,9 @@ include:
   file.directory:
     - name: {{ DOCROOT }}
     - mode: '2775'
-    - group: composer
+    - group: webdev
     - require:
+      - group: user.webdevs webdev group
 {%- if pillar.mounts %}
 {%- for mount in pillar.mounts %}
       - mount: mount mount {{ mount.file }}
@@ -57,10 +58,10 @@ include:
   file.directory:
     - name: {{ DOCROOT }}/wp
     - mode: '2775'
-    - group: composer
+    - user: composer
+    - group: webdev
     - require:
       - file: {{ sls }} docroot
-      - user: php_cc.composer user
     - require_in:
       - composer: {{ sls }} composer update
 
@@ -83,10 +84,9 @@ include:
   file.directory:
     - name: {{ WP_CONTENT }}/{{ dir }}
     - mode: '2775'
-    - group: composer
+    - group: webdev
     - require:
       - file: {{ sls }} dir wp-content
-      - user: php_cc.composer user
     - require_in:
       - composer: {{ sls }} composer update
 {%- endfor %}
@@ -110,7 +110,8 @@ include:
     - source:
       - salt://wordpress/files/{{ HST }}-composer.json
       - salt://wordpress/files/default-composer.json
-    - mode: '0444'
+    - group: webdev
+    - mode: '0664'
     - template: jinja
     - require:
       - file: {{ sls }} docroot
@@ -125,10 +126,9 @@ include:
       - '{}'
     - replace: False
     - mode: '0664'
-    - group: composer
+    - group: webdev
     - require:
       - file: {{ sls }} docroot
-      - user: php_cc.composer user
     - require_in:
       - composer: {{ sls }} composer update
 
@@ -147,7 +147,8 @@ include:
     - user: composer
     - composer_home: /opt/composer
     - require:
-      - php_cc.composer config.json
+      - file: php_cc.composer config.json
+      - file: {{ sls }} docroot
     - unless:
       - test -f {{ DOCROOT }}/COMPOSER_SALTSTACK_LOCKED
 
@@ -168,10 +169,10 @@ include:
   file.directory:
     - name: {{ DOCROOT }}/wp
     - mode: '2775'
-    - group: composer
+    - group: webdev
     - require:
       - composer: {{ sls }} composer update
-      - user: php_cc.composer user
+      - file: {{ sls }} docroot
 
 
 {{ sls }} symlink wp-content:
@@ -181,5 +182,9 @@ include:
     - force: True
     - backupname: >-
         {{ DOCROOT }}/wp/wp-content.{{ None|strftime("%Y%m%d_%H%M%S") }}
+    - user: composer
+    - group: webdev
+    - require:
+      - file: {{ sls }} docroot
     - onlyif:
       - test -d {{ DOCROOT }}/wp/wp-content

--- a/states/wordpress/composer_site.sls
+++ b/states/wordpress/composer_site.sls
@@ -1,6 +1,8 @@
 #
-# WARNING: Pod "Stage" minions execute composer with dev requirements
-#          (no_dev: False)
+# WARNINGS:
+# - Pod "Stage" minions execute composer with dev requirements (no_dev: False)
+# - If you updated the user/group within this file, be sure to also update the
+#   states/wordpress/files/norm_wp_perms.sh script
 #
 {% set DOCROOT = pillar.wordpress.docroot -%}
 {% set WP_CONTENT = "{}/wp-content".format(DOCROOT) -%}

--- a/states/wordpress/domain_mapping.sls
+++ b/states/wordpress/domain_mapping.sls
@@ -10,6 +10,8 @@
   file.symlink:
     - name: {{ MU_PLUGINS }}/domain_mapping.php
     - target: ../plugins/wordpress-mu-domain-mapping/domain_mapping.php
+    - user: composer
+    - group: webdev
     - require:
       - composer: wordpress.composer_site composer update
     - onlyif:
@@ -20,6 +22,8 @@
   file.symlink:
     - name: {{ DOCROOT }}/wp-content/sunrise.php
     - target: plugins/wordpress-mu-domain-mapping/sunrise.php
+    - user: composer
+    - group: webdev
     - require:
       - file: {{ sls }} symlink domain_mapping.php
     - onlyif:

--- a/states/wordpress/files/norm_wp_perms.sh
+++ b/states/wordpress/files/norm_wp_perms.sh
@@ -1,0 +1,95 @@
+#!/bin/bash
+#
+# Normalize WordPress permissions
+#
+# Goals:
+# - Maximize security / minimize risk
+# - Allow web development without requiring root privilages
+#
+set -o errexit
+set -o errtrace
+set -o nounset
+
+trap '_es=${?};
+    printf "${0}: line ${LINENO}: \"${BASH_COMMAND}\"";
+    printf " exited with a status of ${_es}\n";
+    exit ${_es}' ERR
+
+#### FUNCTIONS ########################################################
+
+headerone() {
+    printf '\e[107m\e[30m'
+    printf '### %-75s' "${1}"
+    printf '\e[0m'
+    echo
+}
+
+headertwo() {
+    printf '\e[47m\e[30m'
+    printf '# %-77s' "${1}"
+    printf '\e[0m'
+    echo
+}
+
+#### MAIN #############################################################
+
+# Find WordPress installations
+WP_CONFIGS=$(find /var/www -maxdepth 2 -type f -name 'wp-config.php' \
+                2>/dev/null \
+                || true)
+for _wp_config in ${WP_CONFIGS}; do
+    WP_DIR="${_wp_config%/*}"
+    headerone 'Normalzing permissions on WordPress top directory:'
+    # backup directory
+    TARGET="${WP_DIR}/backup"
+    headertwo "${TARGET}"
+    if [[ -d "${TARGET}" ]]; then
+        chown -ch root "${TARGET}"
+        chgrp -chR webdev "${TARGET}"
+        chmod -c 2770 "${TARGET}"
+        /usr/bin/find "${TARGET}" \
+            -type d -exec chmod -c 2770 {} + \
+            -o -type f -exec chmod -c 0660 {} + \
+            | sed -e'/retained as/d'
+    fi
+    # vendor symlink
+    TARGET="${WP_DIR}/vendor"
+    headertwo "$(printf '%-43s (symlink)\n' "${TARGET}")"
+    if [[ -L "${TARGET}" ]]; then
+        chown -ch composer:webdev "${TARGET}"
+    fi
+    # wp directory
+    TARGET="${WP_DIR}/wp"
+    headertwo "${TARGET}"
+    if [[ -d "${TARGET}" ]]; then
+        chown -ch composer:webdev "${TARGET}"
+        chmod -c 2775 "${TARGET}"
+        /usr/bin/find "${TARGET}" \
+            -type d -exec chmod -c 2775 {} + \
+            -o -type f -exec chmod -c 0664 {} + \
+            | sed -e'/retained as/d'
+    fi
+    # wp-content directory
+    TARGET="${WP_DIR}/wp-content"
+    headertwo "${TARGET}"
+    if [[ -d "${TARGET}" ]]; then
+        chown -ch root:root "${TARGET}"
+        # Why 00555 instead of 0555? See:
+        # https://www.gnu.org/software/coreutils/manual/html_node/Directory-Setuid-and-Setgid.html
+        chmod -c 00555 "${TARGET}"
+        # wp-content subdirectories
+        for _dir in $(/usr/bin/find "${TARGET}" -maxdepth 1 -type d); do
+            case ${_dir} in
+                "${TARGET}")    continue;;
+                *uploads)       TARGET_GROUP=www-data;;
+                *)              TARGET_GROUP=webdev;;
+            esac
+            headertwo "$(printf '%-43s group: %s\n' "${_dir}" \
+                            "${TARGET_GROUP}")"
+            chown -chR composer:"${TARGET_GROUP}" "${_dir}"
+            /usr/bin/find "${_dir}" \
+                -type d -exec chmod -c 2775 {} + \
+                -o -type f -exec chmod -c 0664 {} +
+        done
+    fi
+done

--- a/states/wordpress/files/norm_wp_perms.sh
+++ b/states/wordpress/files/norm_wp_perms.sh
@@ -6,6 +6,10 @@
 # - Maximize security / minimize risk
 # - Allow web development without requiring root privilages
 #
+# References
+# - https://wordpress.org/support/article/changing-file-permissions/
+# - https://www.gnu.org/software/coreutils/manual/html_node/Directory-Setuid-and-Setgid.html
+#
 set -o errexit
 set -o errtrace
 set -o nounset
@@ -40,6 +44,13 @@ WP_CONFIGS=$(find /var/www -maxdepth 2 -type f -name 'wp-config.php' \
 for _wp_config in ${WP_CONFIGS}; do
     WP_DIR="${_wp_config%/*}"
     headerone 'Normalzing permissions on WordPress top directory:'
+    # composer.json file
+    TARGET="${WP_DIR}/composer.json"
+    headertwo "${TARGET}"
+    if [[ -f "${TARGET}" ]]; then
+        chgrp -ch webdev "${TARGET}"
+        chmod -c 00664 "${TARGET}"
+    fi
     # backup directory
     TARGET="${WP_DIR}/backup"
     headertwo "${TARGET}"
@@ -52,7 +63,7 @@ for _wp_config in ${WP_CONFIGS}; do
             -o -type f -exec chmod -c 0660 {} + \
             | sed -e'/retained as/d'
     fi
-    # vendor symlink
+    # vendor symlink - unnecessary aesthetics ¯\_(ツ)_/¯
     TARGET="${WP_DIR}/vendor"
     headertwo "$(printf '%-43s (symlink)\n' "${TARGET}")"
     if [[ -L "${TARGET}" ]]; then
@@ -74,22 +85,32 @@ for _wp_config in ${WP_CONFIGS}; do
     headertwo "${TARGET}"
     if [[ -d "${TARGET}" ]]; then
         chown -ch root:root "${TARGET}"
-        # Why 00555 instead of 0555? See:
-        # https://www.gnu.org/software/coreutils/manual/html_node/Directory-Setuid-and-Setgid.html
         chmod -c 00555 "${TARGET}"
         # wp-content subdirectories
         for _dir in $(/usr/bin/find "${TARGET}" -maxdepth 1 -type d); do
+            TARGET_USER=composer
+            TARGET_GROUP=webdev
+            TARGET_FMODE=00664
             case ${_dir} in
-                "${TARGET}")    continue;;
-                *uploads)       TARGET_GROUP=www-data;;
-                *)              TARGET_GROUP=webdev;;
+                "${TARGET}")
+                    continue
+                    ;;
+                *uploads)
+                    TARGET_USER=www-data
+                    TARGET_GROUP=www-data
+                    ;;
+                *wflogs)
+                    TARGET_USER=www-data
+                    TARGET_GROUP=www-data
+                    TARGET_FMODE=00660
+                    ;;
             esac
             headertwo "$(printf '%-43s group: %s\n' "${_dir}" \
                             "${TARGET_GROUP}")"
-            chown -chR composer:"${TARGET_GROUP}" "${_dir}"
+            chown -chR "${TARGET_USER}":"${TARGET_GROUP}" "${_dir}"
             /usr/bin/find "${_dir}" \
                 -type d -exec chmod -c 2775 {} + \
-                -o -type f -exec chmod -c 0664 {} +
+                -o -type f -exec chmod -c "${TARGET_FMODE}" {} +
         done
     fi
 done

--- a/states/wordpress/init.sls
+++ b/states/wordpress/init.sls
@@ -10,3 +10,4 @@ include:
   - php.xml
   - php_cc.composer
   - wordpress.cli
+  - wordpress.norm_perms

--- a/states/wordpress/norm_perms.sls
+++ b/states/wordpress/norm_perms.sls
@@ -1,0 +1,19 @@
+{{ sls }} install script:
+  file.managed:
+    - name: /usr/local/sbin/norm_wp_perms.sh
+    - source: salt://wordpress/files/norm_wp_perms.sh
+    - mode: '0555'
+
+
+{{ sls }} daily backup cron job:
+  cron.present:
+    - name: '/usr/local/sbin/norm_wp_perms.sh >/dev/null'
+    - user: root
+    - identifier: norm_wp_perms
+    - minute: 5
+    - hour: 17
+    - dayweek: Wed
+    - require:
+      - file: {{ sls }} install script
+      - group: user.webdevs webdev group
+      - user: php_cc.composer user

--- a/states/wordpress/queulat.sls
+++ b/states/wordpress/queulat.sls
@@ -4,12 +4,17 @@
 {% set MU_PLUGINS = "{}/mu-plugins".format(WP_CONTENT) -%}
 
 
+# If you updated the user/group of this stanza, be sure to also update
+# the states/wordpress/files/norm_wp_perms.sh script.
 {{ sls }} symlink vendor:
   file.symlink:
     - name: {{ DOCROOT }}/vendor
     - target: wp-content/vendor
+    - user: composer
+    - group: webdev
     - require:
       - composer: wordpress.composer_site composer update
+      - group: user.webdevs webdev group
       - pkg: nodejs installed packages
       - user: php_cc.composer user
     - onlyif:
@@ -21,7 +26,8 @@
     - name: {{ MU_PLUGINS }}/queulat.php
     - source: salt://wordpress/files/queulat.php
     - mode: '0664'
-    - group: composer
+    - user: composer
+    - group: webdev
     - require:
       - file: {{ sls }} symlink vendor
     - onlyif:

--- a/states/wordpress/queulat.sls
+++ b/states/wordpress/queulat.sls
@@ -1,11 +1,14 @@
 # Provides support for the felipelavinz/queulat mu-plugin, if it is installed
+#
+# WARNINGS:
+# - If you updated the user/group within this file, be sure to also update the
+#   states/wordpress/files/norm_wp_perms.sh script
+#
 {% set DOCROOT = pillar.wordpress.docroot -%}
 {% set WP_CONTENT = "{}/wp-content".format(DOCROOT) -%}
 {% set MU_PLUGINS = "{}/mu-plugins".format(WP_CONTENT) -%}
 
 
-# If you updated the user/group of this stanza, be sure to also update
-# the states/wordpress/files/norm_wp_perms.sh script.
 {{ sls }} symlink vendor:
   file.symlink:
     - name: {{ DOCROOT }}/vendor

--- a/states/wordpress/wordfence.sls
+++ b/states/wordpress/wordfence.sls
@@ -1,4 +1,9 @@
 # Provides support for the Wordfence plugin, if it is installed
+#
+# WARNINGS:
+# - If you updated the user/group within this file, be sure to also update the
+#   states/wordpress/files/norm_wp_perms.sh script
+#
 {% set DOCROOT = pillar.wordpress.docroot -%}
 {% set WP_CONTENT = "{}/wp-content".format(DOCROOT) -%}
 {% set PLUGINS = "{}/plugins".format(WP_CONTENT) -%}

--- a/states/wordpress/wordfence.sls
+++ b/states/wordpress/wordfence.sls
@@ -8,10 +8,11 @@
   file.directory:
     - name: {{ PLUGINS }}/wordfence
     - mode: '2775'
-    - group: www-data
+    - user: composer
+    - group: webdev
     - require:
       - composer: wordpress.composer_site composer update
-      - group: php_cc.composer www-data group
+      - group: user.webdevs webdev group
     - onlyif:
       - test -d {{ PLUGINS }}/wordfence
 
@@ -20,8 +21,10 @@
   file.directory:
     - name: {{ DOCROOT }}/wp-content/wflogs
     - mode: '2775'
+    - user: composer
     - group: www-data
     - require:
       - file: {{ sls }} dir wp-content/plugins/wordfence
+      - group: php_cc.composer www-data group
     - onlyif:
       - test -d {{ PLUGINS }}/wordfence


### PR DESCRIPTION
## Fixes
Fixes https://github.com/creativecommons/tech-support/issues/534 (private repo)

## Description
Completely refactor webdev related permissions
- Create a `webdev` group and use that for all directories/files that do not need to be writable by the web server
  - Update all related groups (and adjust permission modes, as appropriate) 
- Add script to enforce user/group/mode
  - Allow `webdev` group to run it without a password
  - Add cronjob to run it weekly, timed to maximize chance that both WebDev and SysAdmin are working (17:05 UTC)

## Technical details
- [Changing File Permissions | WordPress.org](https://wordpress.org/support/article/changing-file-permissions/)
- [Directory Setuid and Setgid (GNU Coreutils)](https://www.gnu.org/software/coreutils/manual/html_node/Directory-Setuid-and-Setgid.html)
  - (extra zero is required to strip setgid. ex. `chmod 00775`)
- Some clean-up (permission mode changes and `composer` group clean-up) was performed manually and is not included in this PR

## Tests
- Changes are already live on all impacted systems (after being tested by both @hugosolar and @TimidRobot on staging environments, then low audience environments)
- `norm_wp_perms.sh` was evaluated using [koalaman/shellcheck](https://github.com/koalaman/shellcheck): ShellCheck, a static analysis tool for shell scripts

## `norm_wp_perms.sh` Output Excerpt
The following `norm_wp_perms.sh` output excerpt demonstrates sloppy insecure file permissions installed by a WordPress plugin being corrected:
```
# /var/www/chapters/wp-content/mu-plugins     group: webdev                    
changed ownership of '/var/www/chapters/wp-content/mu-plugins' from root:webdev to composer:webdev
mode of '/var/www/chapters/wp-content/mu-plugins/queulat/node_modules/rc/index.js' changed from 0775 (rwxrwxr-x) to 0664 (rw-rw-r--)
mode of '/var/www/chapters/wp-content/mu-plugins/queulat/node_modules/rc/cli.js' changed from 0775 (rwxrwxr-x) to 0664 (rw-rw-r--)
mode of '/var/www/chapters/wp-content/mu-plugins/queulat/node_modules/semver/bin/semver' changed from 0775 (rwxrwxr-x) to 0664 (rw-rw-r--)
mode of '/var/www/chapters/wp-content/mu-plugins/queulat/node_modules/tmp/cleanup.sh' changed from 0775 (rwxrwxr-x) to 0664 (rw-rw-r--)
```

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `master` branch of the repository.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
