### PR TITLE
Override PHP settings on chapters to increase upload limit to 100M

### DIFF
--- a/pillars/3_HST/chapters.sls
+++ b/pillars/3_HST/chapters.sls
@@ -15,6 +15,14 @@ mounts:
     opts: defaults
     freq: 0
     pass: 2
+# Also see pillars/php/init.sls
+php:
+  apache2:
+    ini:
+      settings:
+        PHP:
+          post_max_size: 110M
+          upload_max_filesize: 100M
 states:
   letsencrypt.cloudflare: {{ sls }}
   mount: {{ sls }}


### PR DESCRIPTION
## Fixes
Fixes https://github.com/creativecommons/tech-support/issues/535 (private repo)

## Description
Override PHP settings on chapters hosts to increase upload limit to 100M

## Technical details
Changes on hosts:
```diff
--- 
+++ 
@@ -108,7 +108,7 @@
     default_mimetype = text/html
     expose_php = Off 
     log_errors_max_len = 1024
-    post_max_size = 11M 
+    post_max_size = 110M
     report_memleaks = On
     engine = On
     memory_limit = 128M
@@ -117,7 +117,7 @@
     user_dir = 
     serialize_precision = 17
     precision = 14
-    upload_max_filesize = 10M 
+    upload_max_filesize = 100M
     zlib.output_compression = Off 
     ignore_repeated_errors = Off 
     request_order = GP
```

## Tests
Once @hugosolar has verified this on staging, I'll merge and deploy to production.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `master` branch of the repository.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
