### PR TITLE
Use official formulas with version tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,14 +219,13 @@ See [`docs/Orchestration.md`](docs/Orchestration.md).
 
 ## Formula Repositories
 
-- [creativecommons/mysql-formula][mysql-formula]: Install the MySQL client
+- [saltstack-formulas/mysql-formula][mysql-formula]: Install the MySQL client
   and/or server
-- [creativecommons/php-formula][php-formula]: Formula to set up and configure
-  php
+- [saltstack-formulas/php-formula][php-formula]: Formula to set up and
+  configure php
 
-[certbot]:https://github.com/certbot/certbot
-[mysql-formula]:https://github.com/creativecommons/mysql-formula
-[php-formula]:https://github.com/creativecommons/php-formula
+[mysql-formula]: https://github.com/saltstack-formulas/mysql-formula
+[php-formula]: https://github.com/saltstack-formulas/php-formula
 
 
 ## License

--- a/pillars/3_HST/salt-prime.sls
+++ b/pillars/3_HST/salt-prime.sls
@@ -19,11 +19,11 @@ salt:
     mysql-formula:
       url: https://github.com/saltstack-formulas/mysql-formula.git
       refs:
-        base: v0.52.4
+        base: v0.52.7
     php-formula:
       url: https://github.com/saltstack-formulas/php-formula.git
       refs:
-        base: v1.3.0
+        base: v1.3.1
 states:
   mount: {{ sls }}
   wikijs.reports: {{ sls }}

--- a/pillars/3_HST/salt-prime.sls
+++ b/pillars/3_HST/salt-prime.sls
@@ -16,8 +16,14 @@ mounts:
     pass: 2
 salt:
   gitfs_remotes:
-    - git@github.com:creativecommons/mysql-formula.git
-    - git@github.com:creativecommons/php-formula.git
+    mysql-formula:
+      url: https://github.com/saltstack-formulas/mysql-formula.git
+      refs:
+        base: v0.52.4
+    php-formula:
+      url: https://github.com/saltstack-formulas/php-formula.git
+      refs:
+        base: v1.3.0
 states:
   mount: {{ sls }}
   wikijs.reports: {{ sls }}

--- a/states/salt/files/file-pillar_roots.conf
+++ b/states/salt/files/file-pillar_roots.conf
@@ -1,3 +1,4 @@
+# Managed by SaltStack: {{ SLS }}
 ### roots: Master's Local File Server (Master)
 ### File Directory Settings           (Minion)
 file_roots:
@@ -5,12 +6,10 @@ file_roots:
   base:
     - /srv/base/states
   # Development Environments
-  alden:
-    - /srv/alden/states
-  kgodey:
-    - /srv/kgodey/states
-  timidrobot:
-    - /srv/timidrobot/states
+  {%- for username in pillar.user.admins.keys()|sort %}
+  {{ username }}:
+    - /srv/{{ username }}/states
+  {%- endfor %}
 
 ### Pillar Configuration
 pillar_roots:
@@ -18,11 +17,9 @@ pillar_roots:
   base:
     - /srv/base/pillars
   # Development Environments
-  alden:
-    - /srv/alden/pillars
-  kgodey:
-    - /srv/kgodey/pillars
-  timidrobot:
-    - /srv/timidrobot/pillars
+  {%- for username in pillar.user.admins.keys()|sort %}
+  {{ username }}:
+    - /srv/{{ username }}/pillars
+  {%- endfor %}
 
 # vim: ft=yaml

--- a/states/salt/files/salt_master.conf
+++ b/states/salt/files/salt_master.conf
@@ -1,3 +1,4 @@
+# Managed by SaltStack: {{ SLS }}
 ### Primary Master Configuration
 timeout: 3
 enable_gpu_grains: False

--- a/states/salt/files/salt_master.conf
+++ b/states/salt/files/salt_master.conf
@@ -43,34 +43,30 @@ gitfs_provider: gitpython
 gitfs_ref_types:
   - tag
 gitfs_remotes:
-{%- for repo in pillar.salt.gitfs_remotes.keys()|sort %}
-{%- set remote = pillar.salt.gitfs_remotes[repo] %}
+  {%- for repo in pillar.salt.gitfs_remotes.keys()|sort %}
+  {%- set remote = pillar.salt.gitfs_remotes[repo] %}
   # {{ repo }}
   - {{ remote.url }}:
-{%- if remote.refs|length == 1 %}
-    - all_saltenvs: {{ remote.refs.base }}
-{%- else %}
     # Default/Production Environment
     - base: {{ remote.refs.base }}
     - saltenv:
       - base:
         - ref: {{ remote.refs.base }}
     # Development Environments
-  {%- for username in pillar.user.admins.keys()|sort %}
+    {%- for username in pillar.user.admins.keys()|sort %}
     {%- set ref = salt["pillar.get"]("salt:gitfs_remotes:" + repo + ":refs:"
-                                   + username, remote.refs.base) %}
+                                     + username, remote.refs.base) %}
       - {{ username }}:
         - ref: {{ ref }}
   {%- endfor %}
-{%- endif %}
-{%- endfor %}
+  {%- endfor %}
 gitfs_saltenv_whitelist:
   # Only enable the base and admin-named salt environments (otherwise all
   # tags/branches for each remote are made available)
-{%- set saltenvs = ["base"] + pillar.user.admins.keys() %}
-{%- for saltenv in saltenvs|sort %}
+  {%- set saltenvs = ["base"] + pillar.user.admins.keys() %}
+  {%- for saltenv in saltenvs|sort %}
   - {{ saltenv }}
-{%- endfor %}
+  {%- endfor %}
 
 ### Pillar Configuration
 # (also see file-pillar_roots.conf)

--- a/states/salt/files/salt_master.conf
+++ b/states/salt/files/salt_master.conf
@@ -38,25 +38,39 @@ file_ignore_glob:
 # (also see file-pillar_roots.conf)
 
 ### gitfs: Git Remote File Server Backend
-gitfs_remotes:
-{%- for remote in pillar.salt.gitfs_remotes|sort %}
-  - {{ remote -}}
-{% endfor %}
-gitfs_provider: pygit2
-gitfs_saltenv:
-  # Default/Production Environment
-  - base:
-    - ref: master
-  # Development Environments
-  - alden:
-    - ref: master
-  - kgodey:
-    - ref: master
-  - timidrobot:
-    - ref: master
 gitfs_global_lock: False
-gitfs_pubkey: /root/.ssh/{{ pillar.infra.github.ssh_key.comment }}.pub
-gitfs_privkey: /root/.ssh/{{ pillar.infra.github.ssh_key.comment }}
+gitfs_provider: gitpython
+gitfs_ref_types:
+  - tag
+gitfs_remotes:
+{%- for repo in pillar.salt.gitfs_remotes.keys()|sort %}
+{%- set remote = pillar.salt.gitfs_remotes[repo] %}
+  # {{ repo }}
+  - {{ remote.url }}:
+{%- if remote.refs|length == 1 %}
+    - all_saltenvs: {{ remote.refs.base }}
+{%- else %}
+    # Default/Production Environment
+    - base: {{ remote.refs.base }}
+    - saltenv:
+      - base:
+        - ref: {{ remote.refs.base }}
+    # Development Environments
+  {%- for username in pillar.user.admins.keys()|sort %}
+    {%- set ref = salt["pillar.get"]("salt:gitfs_remotes:" + repo + ":refs:"
+                                   + username, remote.refs.base) %}
+      - {{ username }}:
+        - ref: {{ ref }}
+  {%- endfor %}
+{%- endif %}
+{%- endfor %}
+gitfs_saltenv_whitelist:
+  # Only enable the base and admin-named salt environments (otherwise all
+  # tags/branches for each remote are made available)
+{%- set saltenvs = ["base"] + pillar.user.admins.keys() %}
+{%- for saltenv in saltenvs|sort %}
+  - {{ saltenv }}
+{%- endfor %}
 
 ### Pillar Configuration
 # (also see file-pillar_roots.conf)

--- a/states/salt/files/salt_minion.conf
+++ b/states/salt/files/salt_minion.conf
@@ -1,3 +1,4 @@
+# Managed by SaltStack: {{ SLS }}
 ### Minion Primary Configuration
 master: {{ pillar.location.salt_prime_ip }}
 master_finger: {{ pillar.location.salt_prime_fingerprint }}

--- a/states/salt/minion.sls
+++ b/states/salt/minion.sls
@@ -75,6 +75,8 @@
     - source: salt://salt/files/salt_minion.conf
     - mode: '0444'
     - template: jinja
+    - defaults:
+        SLS: {{ sls }}
     - follow_symlinks: False
     - require:
       - pkg: {{ sls }} installed packages
@@ -87,6 +89,9 @@
     - name: /etc/salt/minion.d/file-pillar_roots.conf
     - source: salt://salt/files/file-pillar_roots.conf
     - mode: '0444'
+    - template: jinja
+    - defaults:
+        SLS: {{ sls }}
     - follow_symlinks: False
     - require:
       - pkg: {{ sls }} installed packages

--- a/states/salt/prime.sls
+++ b/states/salt/prime.sls
@@ -96,6 +96,8 @@
     - source: salt://salt/files/salt_master.conf
     - mode: '0444'
     - template: jinja
+    - defaults:
+        SLS: {{ sls }}
     - follow_symlinks: False
     - require:
       - file: {{ sls }} roster.d directory
@@ -107,6 +109,9 @@
     - name: /etc/salt/master.d/file-pillar_roots.conf
     - source: salt://salt/files/file-pillar_roots.conf
     - mode: '0444'
+    - template: jinja
+    - defaults:
+        SLS: {{ sls }}
     - follow_symlinks: False
     - require:
       - file: {{ sls }} master config file

--- a/states/salt/prime.sls
+++ b/states/salt/prime.sls
@@ -13,10 +13,10 @@
       - ipv6calc
       - python-boto
       - python-boto3
-      - python-pygit2
+      - python-git
       - python3-boto
       - python3-boto3
-      - python3-pygit2
+      - python3-git
       - salt-master
       - salt-ssh
 


### PR DESCRIPTION
## Description
switch to using official formula with version tag
- use official formula via HTTPS and a specific version tag
  - `mysql-formula` updated from `58fd821`/`v0.52.4` to `v0.52.6`
  - `php-formula` updated from `6492871`/`v1.2.3` to `v1.3.0`
  - using a specific version prevents unexpected changes (when gitfs was originally setup for this repository, the official formulas were not versioned)
- limit gitfs to only tags (increased security and speed)
  - otherwise branches are also evaluated
- limit gitfs to only the configured saltenvs (increasing security and speed)
  - otherwise every tag is made available as a saltenv

## Technical details
Almost all of the changes are to the salt-master configuration:
```diff
--- /etc/salt/master.d/salt_master.conf
+++ /etc/salt/master.d/salt_master.conf
@@ -1,3 +1,4 @@
+# Managed by SaltStack: salt.prime
 ### Primary Master Configuration
 timeout: 3
 enable_gpu_grains: False
@@ -38,24 +39,46 @@
 # (also see file-pillar_roots.conf)
 
 ### gitfs: Git Remote File Server Backend
+gitfs_global_lock: False
+gitfs_provider: gitpython
+gitfs_ref_types:
+  - tag 
 gitfs_remotes:
-  - git@github.com:creativecommons/mysql-formula.git
-  - git@github.com:creativecommons/php-formula.git
-gitfs_provider: pygit2
-gitfs_saltenv:
-  # Default/Production Environment
-  - base:
-    - ref: master
-  # Development Environments
-  - alden:
-    - ref: master
-  - kgodey:
-    - ref: master
-  - timidrobot:
-    - ref: master
-gitfs_global_lock: False
-gitfs_pubkey: /root/.ssh/cc-sre-salt-formulas-bot_rsa_github_20190123.pub
-gitfs_privkey: /root/.ssh/cc-sre-salt-formulas-bot_rsa_github_20190123
+  # mysql-formula
+  - https://github.com/saltstack-formulas/mysql-formula.git:
+    # Default/Production Environment
+    - base: v0.52.7
+    - saltenv:
+      - base:
+        - ref: v0.52.7
+    # Development Environments
+      - alden:
+        - ref: v0.52.7
+      - kgodey:
+        - ref: v0.52.7
+      - timidrobot:
+        - ref: v0.52.7
+  # php-formula
+  - https://github.com/saltstack-formulas/php-formula.git:
+    # Default/Production Environment
+    - base: v1.3.1
+    - saltenv:
+      - base:
+        - ref: v1.3.1
+    # Development Environments
+      - alden:
+        - ref: v1.3.1
+      - kgodey:
+        - ref: v1.3.1
+      - timidrobot:
+        - ref: v1.3.1
+gitfs_saltenv_whitelist:
+  # Only enable the base and admin-named salt environments (otherwise all 
+  # tags/branches for each remote are made available)
+  - alden
+  - base
+  - kgodey
+  - timidrobot
 
 ### Pillar Configuration
 # (also see file-pillar_roots.conf)
```

## Tests
Deployed and verified.
- The `python-pygit2` and `python3-pygit2` packages were purged manually

The following commands were helpful to establish and verify the gitfs status:
```bash
sudo service salt-master restart \
    && sleep 3  \
    && sudo salt-run fileserver.clear_cache  \
    && sudo salt-run fileserver.update  \
    && sudo salt-run fileserver.envs
```
```
watch -c -n1 sudo systemctl --full --no-pager status salt-master
```

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `master` branch of the repository.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
