### PR TITLE
Add composer mail alias and WordPress backup fix

### DIFF
--- a/states/ccengine/transifex.sls
+++ b/states/ccengine/transifex.sls
@@ -32,6 +32,7 @@ include:
     - require:
       - group: {{ sls }} group
       - file: ccengine /srv/ccengine
+      - file: postfix install alias source file aliases
 
 
 {{ sls }} .transifex config:

--- a/states/php_cc/composer.sls
+++ b/states/php_cc/composer.sls
@@ -15,6 +15,7 @@ include:
       - group: user.webdevs webdev group
     - require_in:
       - file: {{ sls }} config.json
+      - file: postfix install alias source file aliases
 
 
 {{ sls }} home:

--- a/states/postfix/files/aliases
+++ b/states/postfix/files/aliases
@@ -4,10 +4,10 @@
 
 # system accounts
 {%- set system_accounts = ["postmaster", "root", "webmaster", "www-data"] %}
-{%- if salt["pillar.get"]("states:wordpress.composer_site", false) %}
+{%- if salt.cmd.run("/usr/bin/getent passwd composer") %}
 {%- set _ = system_accounts.append("composer") %}
 {%- endif %}
-{%- if salt["pillar.get"]("ccengine:translations_update", false) %}
+{%- if salt.cmd.run("/usr/bin/getent passwd transifex") %}
 {%- set _ = system_accounts.append("transifex") %}
 {%- endif %}
 {%- for account in system_accounts|sort %}

--- a/states/postfix/files/aliases
+++ b/states/postfix/files/aliases
@@ -1,17 +1,21 @@
 # Managed by SaltStack: {{ SLS }}
 #
 # See man 5 aliases for format
-postmaster:  {{ pillar.postfix.root_mail }}
-root:        {{ pillar.postfix.root_mail }}
-{%- if ("ccengine" in pillar
-        and "translations_update" in pillar.ccengine
-        and pillar.ccengine.translations_update) %}
-transifex:   {{ pillar.postfix.root_mail }}
-{%- endif %}
-webmaster:   {{ pillar.postfix.root_mail }}
-www-data:    {{ pillar.postfix.root_mail }}
 
-{% for admin in pillar.user.admins.keys() -%}
-{% set mail = pillar.user.admins[admin]["mail"] -%}
-{{ admin }}:  {{ mail }}
-{% endfor -%}
+# system accounts
+{%- set system_accounts = ["postmaster", "root", "webmaster", "www-data"] %}
+{%- if salt["pillar.get"]("states:wordpress:composer_site", false) %}
+{%- set _ = system_accounts.append("composer") %}
+{%- endif %}
+{%- if salt["pillar.get"]("ccengine:translations_update", false) %}
+{%- set _ = system_accounts.append("transifex") %}
+{%- endif %}
+{%- for account in system_accounts|sort %}
+{{ "%-15s %s"|format(account + ":", pillar.postfix.root_mail) }}
+{%- endfor %}
+
+# user accounts
+{%- for account in pillar.user.admins.keys()|sort %}
+{%- set mail = pillar.user.admins[account]["mail"] %}
+{{ "%-15s %s"|format(account + ":", mail) }}
+{%- endfor %}

--- a/states/postfix/files/aliases
+++ b/states/postfix/files/aliases
@@ -4,7 +4,7 @@
 
 # system accounts
 {%- set system_accounts = ["postmaster", "root", "webmaster", "www-data"] %}
-{%- if salt["pillar.get"]("states:wordpress:composer_site", false) %}
+{%- if salt["pillar.get"]("states:wordpress.composer_site", false) %}
 {%- set _ = system_accounts.append("composer") %}
 {%- endif %}
 {%- if salt["pillar.get"]("ccengine:translations_update", false) %}

--- a/states/wordpress/files/backup_wordpress.sh
+++ b/states/wordpress/files/backup_wordpress.sh
@@ -77,7 +77,7 @@ prep_and_erase_backup_destination() {
     else
         mkdir "${DESTINATION}"
     fi
-    chmod g+w ${DESTINATION}
+    chmod g+w ${DESTINATION} 2>/dev/null || true
     local today=$(date -u '+%F')
     local hash=$(date | md5sum)
     local hash=${hash:1:7}


### PR DESCRIPTION
## Description
Add composer mail alias and WordPress backup fix:
-  optionally add composer entry to /etc/aliases and improve formatting
    - add composer entry on appropriate systems
    - sort and align entries for better readability and less change churn
- avoid backup failure if unable to change perms

## Technical details
The lack of a composer entry in /etc/aliases meant some backup errors were being missed

Change examples:
```diff
--- /etc/aliases
+++ /etc/aliases
@@ -1,12 +1,15 @@
 # Managed by SaltStack: postfix
 #
 # See man 5 aliases for format
-postmaster:  [REDACTED]@creativecommons.org
-root:        [REDACTED]@creativecommons.org
-webmaster:   [REDACTED]@creativecommons.org
-www-data:    [REDACTED]@creativecommons.org
 
-timidrobot:  [REDACTED]@creativecommons.org
-alden:  [REDACTED]@creativecommons.org
-kgodey:  [REDACTED]@creativecommons.org
+# system accounts
+composer:       [REDACTED]@creativecommons.org
+postmaster:     [REDACTED]@creativecommons.org
+root:           [REDACTED]@creativecommons.org
+webmaster:      [REDACTED]@creativecommons.org
+www-data:       [REDACTED]@creativecommons.org
 
+# user accounts
+alden:          [REDACTED]@creativecommons.org
+kgodey:         [REDACTED]@creativecommons.org
+timidrobot:     [REDACTED]@creativecommons.org
```
```diff
--- /usr/local/bin/backup_wordpress.sh
+++ /usr/local/bin/backup_wordpress.sh
@@ -77,7 +77,7 @@
     else
         mkdir "${DESTINATION}"
     fi  
-    chmod g+w ${DESTINATION}
+    chmod g+w ${DESTINATION} 2>/dev/null || true
     local today=$(date -u '+%F')
     local hash=$(date | md5sum)
     local hash=${hash:1:7}

```

## Tests
Tested on staging servers

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `master` branch of the repository.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
