### PR TITLE
redirect ca.creativecommons.org -> ca.creativecommons.net

### DIFF
--- a/pillars/5_HST__POD/redirects__core.sls
+++ b/pillars/5_HST__POD/redirects__core.sls
@@ -3,6 +3,7 @@ letsencrypt:
     redirects.creativecommons.org:
       - au-beta.creativecommons.org
       - ca-beta.creativecommons.org
+      - ca.creativecommons.org
       - chapters.creativecommons.org
       - co.creativecommons.org
       - code.creativecommons.org
@@ -31,6 +32,9 @@ nginx:
     - crt: redirects.creativecommons.org
       src: ca-beta.creativecommons.org
       dst: ca-beta.creativecommons.net
+    - crt: redirects.creativecommons.org
+      src: ca.creativecommons.org
+      dst: ca.creativecommons.net
     - crt: redirects.creativecommons.org
       src: co.creativecommons.org
       dst: co.creativecommons.net


### PR DESCRIPTION
## Fixes
Fixes https://github.com/creativecommons/tech-support/issues/474 (private repo)

## Description
Redirect redirect ~~[ca.creativecommons.org](https://ca.creativecommons.org/)--~~> [ca.creativecommons.net](https://ca.creativecommons.net/)

## Technical details
Change is live

## Tests
HTTP:
```shell
http -h http://ca.creativecommons.org/
```
```
HTTP/1.1 301 Moved Permanently
CF-Cache-Status: DYNAMIC
CF-RAY: 5a3dba6bcf18eb29-LAX
Connection: keep-alive
Content-Type: text/html
Date: Mon, 15 Jun 2020 16:39:37 GMT
Location: https://ca.creativecommons.net/
Server: cloudflare
Set-Cookie: __cfduid=de658807c11dbab965260f4bc956112d11592239177; expires=Wed, 15-Jul-20 16:39:37 GMT; path=/; domain=.creativecommons.org; HttpOnly; SameSite=Lax
Strict-Transport-Security: max-age=15768000
Transfer-Encoding: chunked
X-Content-Type-Options: nosniff
X-Frame-Options: deny
X-XSS-Protection: 1; mode=block
cf-request-id: 035a72d75f0000eb2939050200000001
```

HTTPS
```shell
http -h https://ca.creativecommons.org/
```
```
HTTP/1.1 301 Moved Permanently
CF-Cache-Status: DYNAMIC
CF-RAY: 5a3dba868ad30560-LAX
Connection: keep-alive
Content-Type: text/html
Date: Mon, 15 Jun 2020 16:39:42 GMT
Expect-CT: max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
Location: https://ca.creativecommons.net/
Server: cloudflare
Set-Cookie: __cfduid=d0fadd57bbb5601e9706b8818667245021592239181; expires=Wed, 15-Jul-20 16:39:41 GMT; path=/; domain=.creativecommons.org; HttpOnly; SameSite=Lax
Strict-Transport-Security: max-age=15768000
Transfer-Encoding: chunked
X-Content-Type-Options: nosniff
X-Frame-Options: deny
X-XSS-Protection: 1; mode=block
cf-request-id: 035a72e817000005604d2c9200000001
```

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `master` branch of the repository.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
