### PR TITLE
added JETPACK_DEV_DEBUG to wp-config.php

### DIFF
--- a/states/wordpress/files/composer-wp-config.php
+++ b/states/wordpress/files/composer-wp-config.php
@@ -73,5 +73,13 @@ define('SUNRISE',               '{{ pillar.wordpress.sunrise }}');
 define('DISALLOW_FILE_EDIT', True);
 #define('DISALLOW_FILE_MODS', True);
 
+
+# Plugin: Jetpack
+{%- if POD == "stage" %}
+define( 'JETPACK_DEV_DEBUG', True );
+{%- else %}
+define( 'JETPACK_DEV_DEBUG', False );
+{%- endif %}
+
 /** Sets up WordPress vars and included files. */
 require_once(ABSPATH . 'wp-settings.php');

--- a/states/wordpress/files/composer-wp-config.php
+++ b/states/wordpress/files/composer-wp-config.php
@@ -73,7 +73,6 @@ define('SUNRISE',               '{{ pillar.wordpress.sunrise }}');
 define('DISALLOW_FILE_EDIT', True);
 #define('DISALLOW_FILE_MODS', True);
 
-
 # Plugin: Jetpack
 {%- if POD == "stage" %}
 define( 'JETPACK_DEV_DEBUG', True );

--- a/states/wordpress/init.sls
+++ b/states/wordpress/init.sls
@@ -62,6 +62,8 @@ include:
       - salt://wordpress/files/composer-wp-config.php
     - mode: '0444'
     - template: jinja
+    - defaults:
+       POD: {{ POD }}
     - require:
       - file: {{ sls }} docroot
 


### PR DESCRIPTION
## Description
added JETPACK_DEV_DEBUG to wp-config.php

## Technical details
See [Development Mode](https://jetpack.com/support/development-mode/)

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `master` branch of the repository.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
