### PR TITLE
Chapters h5p

### DIFF
--- a/states/wordpress/files/chapters-composer.json
+++ b/states/wordpress/files/chapters-composer.json
@@ -30,7 +30,7 @@
     }
   ],
   "require": {
-    "composer/installers": "1.7",
+    "composer/installers": "1.9",
     "creativecommons/wp-theme-cc-chapter": "2019.8.2",
     "johnpbloch/wordpress": "5.4.1",
     "wpackagist-plugin/advanced-custom-fields": "5.8.11",
@@ -38,6 +38,7 @@
     "wpackagist-plugin/advanced-sidebar-menu": "7.7.3",
     "wpackagist-plugin/be-subpages-widget": "1.7",
     "wpackagist-plugin/google-analytics-for-wordpress": "7.10.4",
+    "wpackagist-plugin/h5p": "1.15.0",
     "wpackagist-plugin/import-markdown": "1.05",
     "wpackagist-plugin/jetpack": "8.5",
     "wpackagist-plugin/redirection": "4.7.2",

--- a/states/wordpress/files/chapters-composer.json
+++ b/states/wordpress/files/chapters-composer.json
@@ -1,57 +1,57 @@
 {
-    "name":"creativecommons/wordpress-chapters",
-    "description":"Creative Commons Chapters WordPress Site via Composer",
-    "authors": [
-        {
-            "name":"Creative Commons",
-            "homepage":"https://github.com/creativecommons/sre-salt-prime"
-        }
-    ],
-    "type": "project",
-    "repositories": [
-        {
-            "type":"composer",
-            "url":"https://wpackagist.org"
-        },
-        {
-            "type":"vcs",
-            "url":"https://github.com/creativecommons/queulat",
-            "no-api":true
-        },
-        {
-            "type":"vcs",
-            "url":"https://github.com/creativecommons/wp-theme-cc-chapter",
-            "no-api":true
-        }
-    ],
-    "config": {
-        "vendor-dir":"wp-content/vendor"
-    },
-    "require": {
-        "composer/installers":"1.7",
-        "creativecommons/wp-theme-cc-chapter":"2019.8.2",
-        "johnpbloch/wordpress":"5.4.1",
-        "wpackagist-plugin/advanced-custom-fields":"5.8.11",
-        "wpackagist-plugin/advanced-menu-widget":"0.4.1",
-        "wpackagist-plugin/advanced-sidebar-menu":"7.7.3",
-        "wpackagist-plugin/be-subpages-widget":"1.7",
-        "wpackagist-plugin/google-analytics-for-wordpress":"7.10.4",
-        "wpackagist-plugin/import-markdown":"1.05",
-        "wpackagist-plugin/jetpack":"8.5",
-        "wpackagist-plugin/redirection":"4.7.2",
-        "wpackagist-plugin/ultimate-addons-for-gutenberg":"1.14.10",
-        "wpackagist-plugin/widget-css-classes":"1.5.4",
-        "wpackagist-plugin/wordpress-importer":"0.7",
-        "wpackagist-plugin/wordpress-mu-domain-mapping":"0.5.5.1",
-        "wpackagist-plugin/wordpress-seo":"14.1",
-        "wpackagist-plugin/wp-latest-posts":"4.8.1",
-        "wpackagist-plugin/wp-mail-smtp":"2.0.1"
-    },
-    "require-dev": {
-        "wpackagist-plugin/debug-bar":"1.0",
-        "wpackagist-plugin/debug-bar-actions-and-filters-addon":"1.5.4"
-    },
-    "extra": {
-        "wordpress-install-dir":"wp"
+  "authors": [
+    {
+      "homepage": "https://github.com/creativecommons/sre-salt-prime",
+      "name": "Creative Commons"
     }
+  ],
+  "config": {
+    "vendor-dir": "wp-content/vendor"
+  },
+  "description": "Creative Commons Chapters WordPress Site via Composer",
+  "extra": {
+    "wordpress-install-dir": "wp"
+  },
+  "name": "creativecommons/wordpress-chapters",
+  "repositories": [
+    {
+      "type": "composer",
+      "url": "https://wpackagist.org"
+    },
+    {
+      "no-api": true,
+      "type": "vcs",
+      "url": "https://github.com/creativecommons/queulat"
+    },
+    {
+      "no-api": true,
+      "type": "vcs",
+      "url": "https://github.com/creativecommons/wp-theme-cc-chapter"
+    }
+  ],
+  "require": {
+    "composer/installers": "1.7",
+    "creativecommons/wp-theme-cc-chapter": "2019.8.2",
+    "johnpbloch/wordpress": "5.4.1",
+    "wpackagist-plugin/advanced-custom-fields": "5.8.11",
+    "wpackagist-plugin/advanced-menu-widget": "0.4.1",
+    "wpackagist-plugin/advanced-sidebar-menu": "7.7.3",
+    "wpackagist-plugin/be-subpages-widget": "1.7",
+    "wpackagist-plugin/google-analytics-for-wordpress": "7.10.4",
+    "wpackagist-plugin/import-markdown": "1.05",
+    "wpackagist-plugin/jetpack": "8.5",
+    "wpackagist-plugin/redirection": "4.7.2",
+    "wpackagist-plugin/ultimate-addons-for-gutenberg": "1.14.10",
+    "wpackagist-plugin/widget-css-classes": "1.5.4",
+    "wpackagist-plugin/wordpress-importer": "0.7",
+    "wpackagist-plugin/wordpress-mu-domain-mapping": "0.5.5.1",
+    "wpackagist-plugin/wordpress-seo": "14.1",
+    "wpackagist-plugin/wp-latest-posts": "4.8.1",
+    "wpackagist-plugin/wp-mail-smtp": "2.0.1"
+  },
+  "require-dev": {
+    "wpackagist-plugin/debug-bar": "1.0",
+    "wpackagist-plugin/debug-bar-actions-and-filters-addon": "1.5.4"
+  },
+  "type": "project"
 }


### PR DESCRIPTION
## Fixes
Fixes https://github.com/creativecommons/wp-theme-cc-chapter/issues/40

## Description
1. Normalized JSON with `jq -SM '.'`
    ```shell
    jq -SM '.' chapters-composer.json > new.json && mv new.json chapters-composer.json
    ```
2. Updated composer/installers from 1.7 to 1.9
3. Added `wpackagist-plugin/h5p`
   - [Interactive Content – H5P – WordPress plugin | WordPress.org](https://wordpress.org/plugins/h5p/)

## Technical details
- ✅  [install php7.0-mbstring on Chapters hosts by TimidRobot · Pull Request #91 · creativecommons/sre-salt-prime](https://github.com/creativecommons/sre-salt-prime/pull/91)
- Will be deployed to production after this PR is merged.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
