### PR TITLE
use explicit salt version repository instead of tracking latest

### DIFF
--- a/states/salt/init.sls
+++ b/states/salt/init.sls
@@ -12,12 +12,14 @@ include:
       - python-apt
 
 
+{% set salt_version_major = pillar.salt.minion_target_version.split(".")[0] -%}
 {% set os = grains['oscodename'] -%}
 {% if os == "stretch" -%}
-  {% set repo_url = "https://repo.saltstack.com/apt/debian/9/amd64/latest" -%}
+  {% set repo_url = ("https://repo.saltstack.com/apt/debian/9/amd64/{}"
+                     .format(salt_version_major)) -%}
 {% else -%}
-  {% set repo_url = ("https://repo.saltstack.com/py3/debian/{}/amd64/latest"
-                     .format(grains['osmajorrelease'])) -%}
+  {% set repo_url = ("https://repo.saltstack.com/py3/debian/{}/amd64/{}"
+                     .format(grains['osmajorrelease'], salt_version_major)) -%}
 {% endif -%}
 {{ sls }} SaltStack Repository:
   pkgrepo.managed:


### PR DESCRIPTION
## Description
Use explicit salt version repository based on `minion_target_version` instead of tracking *latest*

`3001` was recently released with breaking changes. This will allow us to continue to use `3000` until we can do a controlled migration to `3001` (while also avoiding this problem in the future).

(The primary salt server is still on a host that does not support f-strings)

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- N/A I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
