### PR TITLE
Report to wikijs updates

### DIFF
--- a/states/postfix/files/aliases
+++ b/states/postfix/files/aliases
@@ -10,6 +10,9 @@
 {%- if salt.cmd.run("/usr/bin/getent passwd transifex") %}
 {%- set _ = system_accounts.append("transifex") %}
 {%- endif %}
+{%- if salt.cmd.run("/usr/bin/getent passwd wikijs") %}
+{%- set _ = system_accounts.append("wikijs") %}
+{%- endif %}
 {%- for account in system_accounts|sort %}
 {{ "%-15s %s"|format(account + ":", pillar.postfix.root_mail) }}
 {%- endfor %}

--- a/states/wikijs/gsuite_reports.sls
+++ b/states/wikijs/gsuite_reports.sls
@@ -1,10 +1,12 @@
+{% set SECRET = "/srv/wikijs/.gsuite_service_account_secret.json" -%}
+
 include:
   - wikijs.reports_shared
 
 
 {{ sls }} gsuite service account secret:
   file.managed:
-    - name: /srv/wikijs/.gsuite_service_account_secret.json
+    - name: {{ SECRET }}
     - source: salt://wikijs/files/gsuite_service_account_secret.json
     - user: wikijs
     - group: wikijs
@@ -44,11 +46,11 @@ include:
 
 
 {% set python3 = "/srv/wikijs/.venvs/gsuite/bin/python3" -%}
-{% set report_path = ("/srv/wikijs/sre-report-to-wikijs/gsuite/report-{}.py"
-                      .format(report)) -%}
+{% set run_report = ("{} /srv/wikijs/sre-report-to-wikijs/gsuite/report-{}.py"
+                     .format(python3, report)) -%}
 {{ sls }} {{ report }} cron job:
   cron.present:
-    - name: {{ python3 }} {{ report_path }} /srv/wikijs/sre-wiki-js
+    - name: {{ run_report }} --secret-file={{ SECRET }} /srv/wikijs/sre-wiki-js
     - user: wikijs
     - identifier: gsite_{{report}}_report
     - special: "@hourly"


### PR DESCRIPTION
## Fixes
- Fixes https://github.com/creativecommons/tech-support/issues/192 (private repo)
- Fixes #100 

## Description
1. Add alias so wikijs (report) issues are sent out instead of staying in local mail spool
2. G Suite reports: specify abosolute path of secret (script itself has a relative path for default value)

## Tests
Applied and verifed

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- N/A I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
