### PR TITLE
updated cron jobs with random minute

### DIFF
--- a/states/wikijs/amazon_route53_report.sls
+++ b/states/wikijs/amazon_route53_report.sls
@@ -13,20 +13,18 @@ include:
       - pkg: virtualenv installed packages
 
 
-{{ sls }} boto3:
+{%- for package in ["boto3", "GitPython"] %}
+
+
+{{ sls }} {{ package }}:
   pip.installed:
-    - name: boto3
+    - name: {{ package }}
     - bin_env: /srv/wikijs/.venvs/amazon_route53
     - require:
       - virtualenv: {{ sls }} virtualenv
-
-
-{{ sls }} GitPython:
-  pip.installed:
-    - name: GitPython
-    - bin_env: /srv/wikijs/.venvs/amazon_route53
-    - require:
-      - virtualenv: {{ sls }} virtualenv
+    - require_in:
+      - cron: {{ sls }} cron job
+{%- endfor %}
 
 
 {% set python3 = "/srv/wikijs/.venvs/amazon_route53/bin/python3" -%}
@@ -36,7 +34,4 @@ include:
     - name: {{ python3 }} {{ report }} /srv/wikijs/sre-wiki-js
     - user: wikijs
     - identifier: amazon_route53_report
-    - special: "@hourly"
-    - require:
-      - pip: {{ sls }} boto3
-      - pip: {{ sls }} GitPython
+    - minute: random

--- a/states/wikijs/cloudflare_report.sls
+++ b/states/wikijs/cloudflare_report.sls
@@ -37,20 +37,18 @@ include:
       - pkg: virtualenv installed packages
 
 
-{{ sls }} cloudflare:
+{%- for package in ["cloudflare", "GitPython"] %}
+
+
+{{ sls }} {{ package }}:
   pip.installed:
-    - name: cloudflare
+    - name: {{ package }}
     - bin_env: /srv/wikijs/.venvs/cloudflare
     - require:
       - virtualenv: {{ sls }} virtualenv
-
-
-{{ sls }} GitPython:
-  pip.installed:
-    - name: GitPython
-    - bin_env: /srv/wikijs/.venvs/cloudflare
-    - require:
-      - virtualenv: {{ sls }} virtualenv
+    - require_in:
+      - cron: {{ sls }} cron job
+{%- endfor %}
 
 
 {% set python3 = "/srv/wikijs/.venvs/cloudflare/bin/python3" -%}
@@ -60,7 +58,4 @@ include:
     - name: {{ python3 }} {{ report }} /srv/wikijs/sre-wiki-js
     - user: wikijs
     - identifier: cloudflare_report
-    - special: "@hourly"
-    - require:
-      - pip: {{ sls }} cloudflare
-      - pip: {{ sls }} GitPython
+    - minute: random

--- a/states/wikijs/gandi_report.sls
+++ b/states/wikijs/gandi_report.sls
@@ -25,20 +25,18 @@ include:
       - pkg: virtualenv installed packages
 
 
-{{ sls }} GitPython:
+{%- for package in ["GitPython", "requests"] %}
+
+
+{{ sls }} {{ package }}:
   pip.installed:
-    - name: GitPython
+    - name: {{ package }}
     - bin_env: /srv/wikijs/.venvs/gandi
     - require:
       - virtualenv: {{ sls }} virtualenv
-
-
-{{ sls }} requests:
-  pip.installed:
-    - name: requests
-    - bin_env: /srv/wikijs/.venvs/gandi
-    - require:
-      - virtualenv: {{ sls }} virtualenv
+    - require_in:
+      - cron: {{ sls }} cron job
+{%- endfor %}
 
 
 {% set python3 = "/srv/wikijs/.venvs/gandi/bin/python3" -%}
@@ -48,7 +46,4 @@ include:
     - name: {{ python3 }} {{ report }} /srv/wikijs/sre-wiki-js
     - user: wikijs
     - identifier: gandi_report
-    - special: "@hourly"
-    - require:
-      - pip: {{ sls }} GitPython
-      - pip: {{ sls }} requests
+    - minute: random

--- a/states/wikijs/gsuite_reports.sls
+++ b/states/wikijs/gsuite_reports.sls
@@ -53,5 +53,5 @@ include:
     - name: {{ run_report }} --secret-file={{ SECRET }} /srv/wikijs/sre-wiki-js
     - user: wikijs
     - identifier: gsite_{{report}}_report
-    - special: "@hourly"
+    - minute: random
 {%- endfor %}


### PR DESCRIPTION
## Description
updated cron jobs with random minute to decrease chance of resource contention

better solution would be to add error handling and incremental backoffs to the reports, but this is much easier.

## Resulting Changes
```diff
--- wikijs.crontab.old	2020-07-31 15:16:07.455466967 +0000
+++ wikijs.crontab.new	2020-07-31 15:16:14.159490090 +0000
@@ -1,11 +1,11 @@
 # Lines below here are managed by Salt, do not edit
 # SALT_CRON_IDENTIFIER:amazon_route53_report
-@hourly /srv/wikijs/.venvs/amazon_route53/bin/python3 /srv/wikijs/sre-report-to-wikijs/amazon-route53/report.py /srv/wikijs/sre-wiki-js
+20 * * * * /srv/wikijs/.venvs/amazon_route53/bin/python3 /srv/wikijs/sre-report-to-wikijs/amazon-route53/report.py /srv/wikijs/sre-wiki-js
 # SALT_CRON_IDENTIFIER:cloudflare_report
-@hourly /srv/wikijs/.venvs/cloudflare/bin/python3 /srv/wikijs/sre-report-to-wikijs/cloudflare/report.py /srv/wikijs/sre-wiki-js
+2 * * * * /srv/wikijs/.venvs/cloudflare/bin/python3 /srv/wikijs/sre-report-to-wikijs/cloudflare/report.py /srv/wikijs/sre-wiki-js
 # SALT_CRON_IDENTIFIER:gandi_report
-@hourly /srv/wikijs/.venvs/gandi/bin/python3 /srv/wikijs/sre-report-to-wikijs/gandi/report.py /srv/wikijs/sre-wiki-js
+32 * * * * /srv/wikijs/.venvs/gandi/bin/python3 /srv/wikijs/sre-report-to-wikijs/gandi/report.py /srv/wikijs/sre-wiki-js
 # SALT_CRON_IDENTIFIER:gsite_groups_report
-@hourly /srv/wikijs/.venvs/gsuite/bin/python3 /srv/wikijs/sre-report-to-wikijs/gsuite/report-groups.py --secret-file=/srv/wikijs/.gsuite_service_account_secret.json /srv/wikijs/sre-wiki-js
+7 * * * * /srv/wikijs/.venvs/gsuite/bin/python3 /srv/wikijs/sre-report-to-wikijs/gsuite/report-groups.py --secret-file=/srv/wikijs/.gsuite_service_account_secret.json /srv/wikijs/sre-wiki-js
 # SALT_CRON_IDENTIFIER:gsite_users_report
-@hourly /srv/wikijs/.venvs/gsuite/bin/python3 /srv/wikijs/sre-report-to-wikijs/gsuite/report-users.py --secret-file=/srv/wikijs/.gsuite_service_account_secret.json /srv/wikijs/sre-wiki-js
+29 * * * * /srv/wikijs/.venvs/gsuite/bin/python3 /srv/wikijs/sre-report-to-wikijs/gsuite/report-users.py --secret-file=/srv/wikijs/.gsuite_service_account_secret.json /srv/wikijs/sre-wiki-js
```

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
