### PR TITLE
Update ccorg WordPress with changes from web development

### DIFF
--- a/pillars/5_HST__POD/ccorgwp__stage/init.sls
+++ b/pillars/5_HST__POD/ccorgwp__stage/init.sls
@@ -12,7 +12,7 @@ include:
 
 
 ccorg:
-  branch: master
+  branch: staging
 mysql:
   server:
     root_user: {{ SECRETS.mysql.server.root_user }}

--- a/states/wordpress/ccorg.sls
+++ b/states/wordpress/ccorg.sls
@@ -22,8 +22,7 @@
       - pkg: {{ sls }} installed packages
 
 
-{%- for repo in ("new-creativecommons.org", "new-www-plugin",
-                 "new-www-theme") %}
+{%- for repo in ("new-creativecommons.org", "new-www-plugin") %}
 
 
 {{ sls }} {{ repo }} repo:
@@ -66,7 +65,7 @@
 {%- endfor %}
 
 
-{#- new-www-theme symlinks #}
+{#- new-www-plugin symlinks #}
 {%- for target in ("cc-author", "cc-donate", "cc-program", "cc-resource",
                    "cc-taxonomies", "cc-widgets") %}
 
@@ -79,12 +78,3 @@
     - require:
       - file: {{ sls }} new-www-plugin permissions
 {%- endfor %}
-
-
-{{ sls }} symlink new-www-theme:
-  file.symlink:
-    - name: {{ THEMES }}/cc
-    - target: {{ GIT }}/new-www-theme/cc
-    - force: True
-    - require:
-      - file: {{ sls }} new-www-theme permissions

--- a/states/wordpress/files/ccorgwp-composer.json
+++ b/states/wordpress/files/ccorgwp-composer.json
@@ -19,6 +19,11 @@
       "url": "https://wpackagist.org"
     },
     {
+      "no-api": true,
+      "type": "vcs",
+      "url": "https://github.com/creativecommons/wp-theme-creativecommons.org"
+    },
+    {
       "package": {
         "dist": {
           "type": "zip",
@@ -69,6 +74,7 @@
   ],
   "require": {
     "composer/installers": "1.9",
+    "creativecommons/wp-theme-creativecommons.org": "2020.4.1",
     "johnpbloch/wordpress": "5.4.1",
     "junaidbhura/gravityforms": "*",
     "junaidbhura/gravityformspaypal": "*",
@@ -77,7 +83,6 @@
     "wpackagist-plugin/akismet": "4.1.6",
     "wpackagist-plugin/allow-epub-and-mobi-formats-upload": "1.0",
     "wpackagist-plugin/breadcrumb-navxt": "6.4.0",
-    "wpackagist-plugin/cas-maestro": "1.1.3",
     "wpackagist-plugin/classic-editor": "1.5",
     "wpackagist-plugin/co-authors-plus": "3.4.3",
     "wpackagist-plugin/easy-add-thumbnail": "1.1.3",
@@ -98,8 +103,7 @@
     "wpackagist-plugin/widgets-on-pages": "1.4.0",
     "wpackagist-plugin/wordpress-importer": "0.7",
     "wpackagist-plugin/wordpress-seo": "14.1",
-    "wpackagist-plugin/wp-rtl": "1.0",
-    "wpackagist-theme/twentysixteen": "2.1"
+    "wpackagist-plugin/wp-rtl": "1.0"
   },
   "require-dev": {
     "wpackagist-plugin/debug-bar": "1.0",

--- a/states/wordpress/files/ccorgwp-composer.json
+++ b/states/wordpress/files/ccorgwp-composer.json
@@ -21,7 +21,17 @@
     {
       "no-api": true,
       "type": "vcs",
+      "url": "https://github.com/creativecommons/wp-theme-base"
+    },
+    {
+      "no-api": true,
+      "type": "vcs",
       "url": "https://github.com/creativecommons/wp-theme-creativecommons.org"
+    },
+    {
+      "no-api": true,
+      "type": "vcs",
+      "url": "https://github.com/creativecommons/queulat"
     },
     {
       "package": {

--- a/states/wordpress/files/ccorgwp-composer.json
+++ b/states/wordpress/files/ccorgwp-composer.json
@@ -74,7 +74,7 @@
   ],
   "require": {
     "composer/installers": "1.9",
-    "creativecommons/wp-theme-creativecommons.org": "2020.4.1",
+    "creativecommons/wp-theme-creativecommons.org": "2020.07.1",
     "johnpbloch/wordpress": "5.4.1",
     "junaidbhura/gravityforms": "*",
     "junaidbhura/gravityformspaypal": "*",


### PR DESCRIPTION
## Fixes
Fixes https://github.com/creativecommons/tech-support/issues/585 (private repo)

## Description
Captures web development changes:
- removed `cas-maestro` plugin (CCID integration)
- replaced `new-www-theme` with `wp-theme-creativecommons.org` (and `wp-theme-base`)
- removed `twentysixteen` theme

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
