### PR TITLE
Update staging logic to accept any string that starts with "stage"

### DIFF
--- a/states/nginx/cclicdev.sls
+++ b/states/nginx/cclicdev.sls
@@ -22,7 +22,7 @@ include:
       - service: nginx service
 
 
-{%- if pillar.pod == "stage" %}
+{%- if pillar.pod.startswith("stage") %}
 
 
 {{ sls }} installed packages:
@@ -67,7 +67,7 @@ include:
         SLS: {{ sls }}
     - require:
       - pkg: nginx installed packages
-{%- if pillar.pod == "stage" %}
+{%- if pillar.pod.startswith("stage") %}
       - webutil: {{ sls }} basic authentication user exists
 {%- endif %}
     - watch_in:

--- a/states/nginx/dispatch.sls
+++ b/states/nginx/dispatch.sls
@@ -24,7 +24,7 @@ include:
       - service: nginx service
 
 
-{%- if pillar.pod == "stage" %}
+{%- if pillar.pod.startswith("stage") %}
 
 
 {{ sls }} installed packages:
@@ -68,7 +68,7 @@ include:
         SLS: {{ sls }}
     - require:
       - pkg: nginx installed packages
-{%- if pillar.pod == "stage" %}
+{%- if pillar.pod.startswith("stage") %}
       - webutil: {{ sls }} basic authentication user exists
 {%- endif %}
     - watch_in:

--- a/states/nginx/files/cclicdev_tls_template
+++ b/states/nginx/files/cclicdev_tls_template
@@ -12,7 +12,7 @@ server {
     server_name {{ CERT_NAME }};
     ssl_certificate /etc/letsencrypt/live/{{ CERT_NAME }}/fullchain.pem;
     ssl_certificate_key /etc/letsencrypt/live/{{ CERT_NAME }}/privkey.pem;
-{%- if pillar.pod == "stage" %}
+{%- if pillar.pod.startswith("stage") %}
     auth_basic "Staging Environment Restricted";
     auth_basic_user_file /etc/nginx/htpasswd;
 {%- endif %}

--- a/states/nginx/files/dispatch_tls_template
+++ b/states/nginx/files/dispatch_tls_template
@@ -11,7 +11,7 @@ server {
         json_debug buffer=32k flush=2s;
     ssl_certificate /etc/letsencrypt/live/{{ CERT_NAME }}/fullchain.pem;
     ssl_certificate_key /etc/letsencrypt/live/{{ CERT_NAME }}/privkey.pem;
-{%- if pillar.pod == "stage" %}
+{%- if pillar.pod.startswith("stage") %}
     auth_basic "Staging Environment Restricted";
     auth_basic_user_file /etc/nginx/htpasswd;
 {%- endif %}

--- a/states/postfix/files/main.cf
+++ b/states/postfix/files/main.cf
@@ -34,6 +34,6 @@ smtpd_helo_required = yes
 smtpd_tls_ciphers = $smtp_tls_ciphers
 smtpd_tls_dh1024_param_file = /etc/ssl/private/dhparams.pem
 smtpd_tls_exclude_ciphers = $smtp_tls_exclude_ciphers
-{%- if pillar.pod == "stage" %}
+{%- if pillar.pod.startswith("stage") %}
 transport_maps = hash:/etc/postfix/transport
 {%- endif %}

--- a/states/postfix/init.sls
+++ b/states/postfix/init.sls
@@ -37,9 +37,9 @@ include:
 
 {{ pf.install_alias(sls, "0444", "/etc/aliases", "aliases") -}}
 {{ pf.install_map(sls, "0400", "/etc/postfix/sasl_passwd", "sasl_passwd") -}}
-{% if pillar.hst == "cclicdev" and pillar.pod == "stage" -%}
+{% if pillar.hst == "cclicdev" and pillar.pod.startswith("stage") -%}
 {{ pf.install_map(sls, "0400", "/etc/postfix/transport",
                   "transport_stage_caktus") -}}
-{% elif pillar.pod == "stage" -%}
+{% elif pillar.pod.startswith("stage") -%}
 {{ pf.install_map(sls, "0400", "/etc/postfix/transport", "transport_stage") -}}
 {% endif -%}

--- a/states/wordpress/files/composer-wp-config.php
+++ b/states/wordpress/files/composer-wp-config.php
@@ -74,7 +74,7 @@ define('DISALLOW_FILE_EDIT', True);
 #define('DISALLOW_FILE_MODS', True);
 
 # Plugin: Jetpack
-{%- if POD == "stage" %}
+{%- if POD.startswith("stage") %}
 define( 'JETPACK_DEV_DEBUG', True );
 {%- else %}
 define( 'JETPACK_DEV_DEBUG', False );

--- a/states/wordpress/init.sls
+++ b/states/wordpress/init.sls
@@ -172,7 +172,7 @@ include:
     - composer: /usr/local/bin/composer
     - php: /usr/bin/php
     - optimize: True
-{%- if POD == "stage" %}
+{%- if POD.startswith("stage") %}
     - no_dev: False
 {%- else %}
     - no_dev: True


### PR DESCRIPTION
## Description
There are a few spots where there is logic based on whether a staging environment is being configured. This PR updates the logic to test the beginning of the string (`.startswith("stage")`) instead of the entire string (` == "stage"`).

## Technical details
I don't think this is a satisfactory solution to [Add support for multiple instances in a role · Issue #3](https://github.com/creativecommons/sre-salt-prime/issues/3), but it will allow forward movement until I architect a comprehensive solution.

## Tests
I ran SaltStack highstate against all hosts before and after changes to verify that the results are the same (no changes).

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
