### PR TITLE
certbot: loud by default. no password to list certificates

### DIFF
--- a/pillars/letsencrypt/init.sls
+++ b/pillars/letsencrypt/init.sls
@@ -9,7 +9,6 @@ letsencrypt:
     email: {{ secrets.email }}
     expand: True
     keep-until-expiring: True
-    quiet: True
     renew-with-new-domains: True
     server: https://acme-v02.api.letsencrypt.org/directory
     webroot-path: /var/www/html

--- a/states/letsencrypt/init.sls
+++ b/states/letsencrypt/init.sls
@@ -1,5 +1,6 @@
 include:
   - python.pip
+  - sudo.letsencrypt
   - tls
 
 
@@ -98,9 +99,9 @@ include:
   cmd.run:
     - name: >-
 {%- if pillar.letsencrypt.domainsets[domainset] is none %}
-        /usr/local/bin/certbot certonly -d {{ domainset }}
+        /usr/local/bin/certbot --quiet certonly -d {{ domainset }}
 {%- else %}
-        /usr/local/bin/certbot certonly -d {{ domainset }} \
+        /usr/local/bin/certbot --quiet certonly -d {{ domainset }} \
 {%- for domain in pillar.letsencrypt.domainsets[domainset]|sort() %}
 {%- if loop.last %}
           -d {{ domain }}
@@ -118,7 +119,7 @@ include:
 
 {{ sls }} cron certbot renew:
   cron.present:
-    - name: /usr/local/bin/certbot renew
+    - name: /usr/local/bin/certbot --quiet renew
     - identifier: certbot_renew
     - minute: random
     - hour: '0,12'

--- a/states/sudo/files/letsencrypt
+++ b/states/sudo/files/letsencrypt
@@ -1,0 +1,7 @@
+# vim: ft=sudoers
+#
+# This file MUST be edited with `/usr/sbin/visudo -sf FILENAME`.
+
+Cmnd_Alias CERTBOT_CERTIFICATES = /usr/local/bin/certbot certificates
+
+%sudo ALL = NOPASSWD: CERTBOT_CERTIFICATES

--- a/states/sudo/letsencrypt.sls
+++ b/states/sudo/letsencrypt.sls
@@ -1,0 +1,13 @@
+include:
+  - sudo
+
+
+{{ sls }} add letsencrypt:
+  file.managed:
+    - name: /etc/sudoers.d/letsencrypt
+    - source: salt://sudo/files/letsencrypt
+    - mode: '0440'
+    - require:
+      - pkg: sudo installed packages
+    # Reminder: file.managed check_cmd is different than requisite check_cmd
+    - check_cmd: /usr/sbin/visudo -csf


### PR DESCRIPTION
## Description
- Update configuration so certbot is loud by default
  - add `--quiet` to certbot invocations (ex. so we don't email every cron run)
  - work around [No apparent way to override quiet = True in /etc/letsencrypt/cli.ini · Issue #7314 · certbot/certbot](https://github.com/certbot/certbot/issues/7314)
- Add sudo config so no password is required to for `sudo certbot certificates`

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
