### PR TITLE
update LE to 1.10.1 (from 1.0.0) and supporting changes

### DIFF
--- a/pillars/5_HST__POD/chapters__prod/init.sls
+++ b/pillars/5_HST__POD/chapters__prod/init.sls
@@ -23,7 +23,6 @@ letsencrypt:
     expand: True
     keep-until-expiring: True
     preferred-challenges: dns-01
-    quiet: True
     renew-with-new-domains: True
     server: https://acme-v02.api.letsencrypt.org/directory
     webroot-path: /var/www/html

--- a/pillars/5_HST__POD/chapters__stage/init.sls
+++ b/pillars/5_HST__POD/chapters__stage/init.sls
@@ -23,7 +23,6 @@ letsencrypt:
     expand: True
     keep-until-expiring: True
     preferred-challenges: dns-01
-    quiet: True
     renew-with-new-domains: True
     server: https://acme-v02.api.letsencrypt.org/directory
   domainsets:

--- a/pillars/letsencrypt/init.sls
+++ b/pillars/letsencrypt/init.sls
@@ -12,4 +12,4 @@ letsencrypt:
     renew-with-new-domains: True
     server: https://acme-v02.api.letsencrypt.org/directory
     webroot-path: /var/www/html
-  version: "1.0.0"
+  version: "1.10.1"

--- a/states/letsencrypt/cloudflare.sls
+++ b/states/letsencrypt/cloudflare.sls
@@ -1,6 +1,5 @@
 include:
   - letsencrypt
-  - python.pip
 
 
 {{ sls }} root secrets dir:

--- a/states/letsencrypt/init.sls
+++ b/states/letsencrypt/init.sls
@@ -4,6 +4,18 @@ include:
   - tls
 
 
+{% if grains.oscodename == "stretch" -%}
+# Ensure compatible dependencies are installed on Debian 9 (Stretch)
+{{ sls }} install parsedatetime:
+  pip.installed:
+    - name: parsedatetime == 2.5
+    - require:
+      - pkg: python.pip installed packages
+    - require_in:
+      - pip: {{ sls }} install certbot
+{%- endif %}
+
+
 {% if grains['oscodename'] == "buster" -%}
 # Ensure compatible dependencies are installed on Debian 10 (Buster)
 {{ sls }} installed packges:


### PR DESCRIPTION
## Description
1. Update certbot to version `1.10.1` (from `1.0.0`, see [Releases · certbot/certbot](https://github.com/certbot/certbot/releases))
   - Manage `parsedatetime` on Debian Stretch to avoid error:
        ```
        AttributeError: 'module' object has no attribute 'Locale'
        ```
2. Remove `quiet = True` HST__POD overrides (should have been included in #132)

## Tests
Correct functioning of certbot was verified on all hosts with:
```shell
sudo salt \* cmd.run 'test -f /etc/letsencrypt/cli.ini && certbot certificates || true'
```

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
