### PR TITLE
redirect CC Search to WordPress Openverse

### DIFF
--- a/pillars/5_HST__POD/redirects__core.sls
+++ b/pillars/5_HST__POD/redirects__core.sls
@@ -3,6 +3,11 @@ letsencrypt:
     creativecommons.dk:
       - creativecommons.dk
       - www.creativecommons.dk
+    creativecommons.engineering:
+      - api.creativecommons.engineering
+      - api-dev.creativecommons.engineering
+      - search-dev.creativecommons.engineering
+      - search-prod.creativecommons.engineering
     creativecommons.ru:
       - creativecommons.ru
       - www.creativecommons.ru
@@ -27,6 +32,7 @@ letsencrypt:
       - nl-beta.creativecommons.org
       - nl.creativecommons.org
       - pl.creativecommons.org
+      - search.creativecommons.org
       - sotc.creativecommons.org
       - sv.creativecommons.org
       - za.creativecommons.org

--- a/states/nginx/files/api.creativecommons.engineering
+++ b/states/nginx/files/api.creativecommons.engineering
@@ -1,0 +1,36 @@
+# vim: ft=nginx:
+
+
+server {
+    listen 80;
+    listen [::]:80;
+    server_name
+        api.creativecommons.engineering
+        api-dev.creativecommons.engineering;
+    access_log off;
+    # Enable letsencrypt authorization
+    location /.well-known {
+        default_type "text/plain";
+        root /var/www/html;
+    }
+    # Redirect everything else
+    # (will purposely break API calls, but bring humans to current documentation)
+    location / {
+        return 301 https://api.openverse.engineering/?referrer=creativecommons.org;
+    }
+}
+
+
+server {
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
+    server_name
+        api.creativecommons.engineering
+        api-dev.creativecommons.engineering;
+    access_log off;
+    ssl_certificate /etc/letsencrypt/live/creativecommons.engineering/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/creativecommons.engineering/privkey.pem;
+    # Redirect everything
+    # (will purposely break API calls, but bring humans to current documentation)
+    return 301 https://api.openverse.engineering/?referrer=creativecommons.org;
+}

--- a/states/nginx/files/search.creativecommons.engineering
+++ b/states/nginx/files/search.creativecommons.engineering
@@ -1,0 +1,46 @@
+# vim: ft=nginx:
+
+
+server {
+    listen 80;
+    listen [::]:80;
+    server_name
+        search-prod.creativecommons.org
+        search-dev.creativecommons.org;
+    access_log off;
+    # Enable letsencrypt authorization
+    location /.well-known {
+        default_type "text/plain";
+        root /var/www/html;
+    }
+    # Redirect special image files
+    location /static/img/ {
+        return 301 https://search.openverse.engineering$uri?referrer=creativecommons.org&$args;
+
+    }
+    # Redirect everything else
+    location / {
+        return 301 https://wordpress.org/openverse$uri?referrer=creativecommons.org&$args;
+    }
+}
+
+
+server {
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
+    server_name
+        search-prod.creativecommons.org
+        search-dev.creativecommons.org;
+    access_log off;
+    ssl_certificate /etc/letsencrypt/live/creativecommons.engineering/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/creativecommons.engineering/privkey.pem;
+    # Redirect special image files
+    location /static/img/ {
+        return 301 https://search.openverse.engineering$uri?referrer=creativecommons.org&$args;
+
+    }
+    # Redirect everything else
+    location / {
+        return 301 https://wordpress.org/openverse$uri?referrer=creativecommons.org&$args;
+    }
+}

--- a/states/nginx/files/search.creativecommons.engineering
+++ b/states/nginx/files/search.creativecommons.engineering
@@ -8,6 +8,9 @@ server {
         search-prod.creativecommons.org
         search-dev.creativecommons.org;
     access_log off;
+    if ( $is_args ) {
+        set $sep_args "&";
+    }
     # Enable letsencrypt authorization
     location /.well-known {
         default_type "text/plain";
@@ -15,12 +18,12 @@ server {
     }
     # Redirect special image files
     location /static/img/ {
-        return 301 https://search.openverse.engineering$uri?referrer=creativecommons.org&$args;
+        return 301 https://search.openverse.engineering$uri?referrer=creativecommons.org$sep_args$args;
 
     }
     # Redirect everything else
     location / {
-        return 301 https://wordpress.org/openverse$uri?referrer=creativecommons.org&$args;
+        return 301 https://wordpress.org/openverse$uri?referrer=creativecommons.org$sep_args$args;
     }
 }
 
@@ -34,13 +37,16 @@ server {
     access_log off;
     ssl_certificate /etc/letsencrypt/live/creativecommons.engineering/fullchain.pem;
     ssl_certificate_key /etc/letsencrypt/live/creativecommons.engineering/privkey.pem;
+    if ( $is_args ) {
+        set $sep_args "&";
+    }
     # Redirect special image files
     location /static/img/ {
-        return 301 https://search.openverse.engineering$uri?referrer=creativecommons.org&$args;
+        return 301 https://search.openverse.engineering$uri?referrer=creativecommons.org$sep_args$args;
 
     }
     # Redirect everything else
     location / {
-        return 301 https://wordpress.org/openverse$uri?referrer=creativecommons.org&$args;
+        return 301 https://wordpress.org/openverse$uri?referrer=creativecommons.org$sep_args$args;
     }
 }

--- a/states/nginx/files/search.creativecommons.org
+++ b/states/nginx/files/search.creativecommons.org
@@ -6,6 +6,9 @@ server {
     listen [::]:80;
     server_name search.creativecommons.org;
     access_log off;
+    if ( $is_args ) {
+        set $sep_args "&";
+    }
     # Enable letsencrypt authorization
     location /.well-known {
         default_type "text/plain";
@@ -13,12 +16,12 @@ server {
     }
     # Redirect special image files
     location /static/img/ {
-        return 301 https://search.openverse.engineering$uri?referrer=creativecommons.org&$args;
+        return 301 https://search.openverse.engineering$uri?referrer=creativecommons.org$sep_args$args;
 
     }
     # Redirect everything else
     location / {
-        return 301 https://wordpress.org/openverse$uri?referrer=creativecommons.org&$args;
+        return 301 https://wordpress.org/openverse$uri?referrer=creativecommons.org$sep_args$args;
     }
 }
 
@@ -30,13 +33,16 @@ server {
     access_log off;
     ssl_certificate /etc/letsencrypt/live/redirects.creativecommons.org/fullchain.pem;
     ssl_certificate_key /etc/letsencrypt/live/redirects.creativecommons.org/privkey.pem;
+    if ( $is_args ) {
+        set $sep_args "&";
+    }
     # Redirect special image files
     location /static/img/ {
-        return 301 https://search.openverse.engineering$uri?referrer=creativecommons.org&$args;
+        return 301 https://search.openverse.engineering$uri?referrer=creativecommons.org$sep_args$args;
 
     }
     # Redirect everything else
     location / {
-        return 301 https://wordpress.org/openverse$uri?referrer=creativecommons.org&$args;
+        return 301 https://wordpress.org/openverse$uri?referrer=creativecommons.org$sep_args$args;
     }
 }

--- a/states/nginx/files/search.creativecommons.org
+++ b/states/nginx/files/search.creativecommons.org
@@ -1,0 +1,42 @@
+# vim: ft=nginx:
+
+
+server {
+    listen 80;
+    listen [::]:80;
+    server_name search.creativecommons.org;
+    access_log off;
+    # Enable letsencrypt authorization
+    location /.well-known {
+        default_type "text/plain";
+        root /var/www/html;
+    }
+    # Redirect special image files
+    location /static/img/ {
+        return 301 https://search.openverse.engineering$uri?referrer=creativecommons.org&$args;
+
+    }
+    # Redirect everything else
+    location / {
+        return 301 https://wordpress.org/openverse$uri?referrer=creativecommons.org&$args;
+    }
+}
+
+
+server {
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
+    server_name search.creativecommons.org;
+    access_log off;
+    ssl_certificate /etc/letsencrypt/live/redirects.creativecommons.org/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/redirects.creativecommons.org/privkey.pem;
+    # Redirect special image files
+    location /static/img/ {
+        return 301 https://search.openverse.engineering$uri?referrer=creativecommons.org&$args;
+
+    }
+    # Redirect everything else
+    location / {
+        return 301 https://wordpress.org/openverse$uri?referrer=creativecommons.org&$args;
+    }
+}

--- a/states/nginx/redirects.sls
+++ b/states/nginx/redirects.sls
@@ -63,4 +63,68 @@ include:
 {%- endfor %}
 
 
+# CC Search sites require non-standard redirects
+
+{{ sls }} install site search.creativecommons.engineering:
+  file.managed:
+    - name: /etc/nginx/sites-available/search.creativecommons.engineering
+    - source: salt://nginx/files/search.creativecommons.engineering
+    - mode: '0444'
+    - require:
+      - file: {{ sls }} enable site {{ DEFAULT_CERT }}
+    - watch_in:
+      - service: nginx service
+
+
+{{ sls }} enable site search.creativecommons.engineering:
+  file.symlink:
+    - name: /etc/nginx/sites-enabled/search.creativecommons.engineering
+    - target: /etc/nginx/sites-available/search.creativecommons.engineering
+    - require:
+      - file: {{ sls }} install site search.creativecommons.engineering
+    - watch_in:
+      - service: nginx service
+
+
+{{ sls }} install site search.creativecommons.org:
+  file.managed:
+    - name: /etc/nginx/sites-available/search.creativecommons.org
+    - source: salt://nginx/files/search.creativecommons.org
+    - mode: '0444'
+    - require:
+      - file: {{ sls }} enable site {{ DEFAULT_CERT }}
+    - watch_in:
+      - service: nginx service
+
+
+{{ sls }} enable site search.creativecommons.org:
+  file.symlink:
+    - name: /etc/nginx/sites-enabled/search.creativecommons.org
+    - target: /etc/nginx/sites-available/search.creativecommons.org
+    - require:
+      - file: {{ sls }} install site search.creativecommons.org
+    - watch_in:
+      - service: nginx service
+
+{{ sls }} install site api.creativecommons.engineering:
+  file.managed:
+    - name: /etc/nginx/sites-available/api.creativecommons.engineering
+    - source: salt://nginx/files/api.creativecommons.engineering
+    - mode: '0444'
+    - require:
+      - file: {{ sls }} enable site {{ DEFAULT_CERT }}
+    - watch_in:
+      - service: nginx service
+
+
+{{ sls }} enable site api.creativecommons.engineering:
+  file.symlink:
+    - name: /etc/nginx/sites-enabled/api.creativecommons.engineering
+    - target: /etc/nginx/sites-available/api.creativecommons.engineering
+    - require:
+      - file: {{ sls }} install site api.creativecommons.engineering
+    - watch_in:
+      - service: nginx service
+
+
 {{ nginx.disable_sites(sls, ["default"]) -}}


### PR DESCRIPTION
## Description
redirect CC Search to WordPress Openverse

## Technical details
- Special images are handled (resolves [Preserve images that appear in embedded attribution from CC Search · Issue #704 · creativecommons/tech-support](https://github.com/creativecommons/tech-support/issues/704)
- API calls are purposely broken, but humans are brought to current API documentation
- changes are live in production
- DNS changes were made manually

## Tests

### Image result URL
```
curl -IL 'https://search.creativecommons.org/photos/7880c095-3034-4ab7-9460-387b1953ca58'
```
```
HTTP/2 301 
location: https://wordpress.org/openverse/photos/7880c095-3034-4ab7-9460-387b1953ca58?referrer=creativecommons.org
[...]

HTTP/2 200 
[...]
```

### Special image handling
```
curl -IL 'https://search.creativecommons.org/static/img/cc_icon.svg?image_id=1212275a-c4fe-44e6-ae86-419e6f3f0c90'
```
```
HTTP/2 301 
location: https://search.openverse.engineering/static/img/cc_icon.svg?referrer=creativecommons.org&image_id=1212275a-c4fe-44e6-ae86-419e6f3f0c90
[...]

HTTP/2 404 
[...]
```
(this 404 is a known issue: the location above is correct)

### API call
```
curl -IL 'https://api.creativecommons.engineering/anything/because/path/is/stripped'
```
```
HTTP/2 301 
location: https://api.openverse.engineering/?referrer=creativecommons.org
[...]

HTTP/2 302 
location: /v1/
[...]

HTTP/2 200 
[...]
```

## Screenshots
<!-- Add screenshots to show the problem and the solution; or delete this section entirely. -->

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

For the purposes of this DCO, "license" is equivalent to "license or public domain dedication," and "open source license" is equivalent to "open content license or public domain dedication."
<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
