### PR TITLE
update ccorg__stage composer config

### DIFF
--- a/states/wordpress/files/ccorg-composer.json
+++ b/states/wordpress/files/ccorg-composer.json
@@ -6,6 +6,10 @@
     }
   ],
   "config": {
+    "allow-plugins": {
+      "composer/installers": true,
+      "johnpbloch/wordpress-core-installer": true
+    },
     "vendor-dir": "wp-content/vendor"
   },
   "description": "Creative Commons Primary WordPress Site via Composer",
@@ -36,7 +40,7 @@
   ],
   "require": {
     "composer/installers": "^1.0",
-    "creativecommons/wp-plugin-creativecommons-website": "2022.2.1",
+    "creativecommons/wp-theme-creativecommons.org": "2022.02.1",
     "johnpbloch/wordpress": "5.9.0",
     "wpackagist-plugin/ultimate-addons-for-gutenberg": "1.25.3",
     "wpackagist-plugin/wordpress-seo": "18.0"


### PR DESCRIPTION
## Description
- update ccorg__stage composer config to install all working themes and working plugins that have been confirmed in [[Bug] WordPress Plugins do not match legacy production or previous staging · Issue #212 · creativecommons/project_creativecommons.org](https://github.com/creativecommons/project_creativecommons.org/issues/212).
- *(additional work is required before completion of #155)*

## Technical details
Test:
```
sudo salt ccorg__stage\* cmd.run 'rm -f /var/www/stage.creativecommons.org/COMPOSER_SALTSTACK_LOCKED'
sudo salt ccorg__stage\* state.highstate saltenv=${USER} test=True
```
Apply:
```
sudo salt ccorg__stage\* cmd.run 'rm -f /var/www/stage.creativecommons.org/COMPOSER_SALTSTACK_LOCKED'
sudo salt ccorg__stage\* state.highstate saltenv=${USER} test=
```

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

For the purposes of this DCO, "license" is equivalent to "license or public domain dedication," and "open source license" is equivalent to "open content license or public domain dedication."
<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
