### PR TITLE
stage.creativecommons.org WordPress updates

### DIFF
--- a/states/wordpress/files/ccorg-composer.json
+++ b/states/wordpress/files/ccorg-composer.json
@@ -41,7 +41,7 @@
   "require": {
     "composer/installers": "^1.0",
     "creativecommons/wp-plugin-creativecommons-website": "0.5.0",
-    "creativecommons/wp-theme-creativecommons.org": "2022.02.2",
+    "creativecommons/wp-theme-creativecommons.org": "2022.03.2",
     "johnpbloch/wordpress": "5.9.3",
     "wpackagist-plugin/ultimate-addons-for-gutenberg": "1.25.4",
     "wpackagist-plugin/wordpress-importer": "0.7",

--- a/states/wordpress/files/ccorg-composer.json
+++ b/states/wordpress/files/ccorg-composer.json
@@ -40,15 +40,15 @@
   ],
   "require": {
     "composer/installers": "^1.0",
-    "creativecommons/wp-plugin-creativecommons-website": "0.2.0",
-    "creativecommons/wp-theme-creativecommons.org": "2022.02.1",
-    "johnpbloch/wordpress": "5.9.0",
-    "wpackagist-plugin/ultimate-addons-for-gutenberg": "1.25.3",
+    "creativecommons/wp-plugin-creativecommons-website": "0.5.0",
+    "creativecommons/wp-theme-creativecommons.org": "2022.02.2",
+    "johnpbloch/wordpress": "5.9.3",
+    "wpackagist-plugin/ultimate-addons-for-gutenberg": "1.25.4",
     "wpackagist-plugin/wordpress-importer": "0.7",
-    "wpackagist-plugin/wordpress-seo": "18.0"
+    "wpackagist-plugin/wordpress-seo": "18.5.1"
   },
   "require-dev": {
-    "wpackagist-plugin/debug-bar": "1.0",
+    "wpackagist-plugin/debug-bar": "1.1.2",
     "wpackagist-plugin/debug-bar-actions-and-filters-addon": "1.5.4"
   },
   "type": "project"


### PR DESCRIPTION
## Description
stage.creativecommons.org WordPress updates

## Technical Details
On server:
```
wp --path=/var/www/stage.creativecommons.org/wp --url=stage.creativecommons.org plugin list
```
```
+-------------------------------------+----------+--------+---------+
| name                                | status   | update | version |
+-------------------------------------+----------+--------+---------+
| wp-plugin-creativecommons-website   | inactive | none   | 0.5.0   |
| debug-bar                           | inactive | none   | 1.1.2   |
| debug-bar-actions-and-filters-addon | inactive | none   | 1.5.4   |
| ultimate-addons-for-gutenberg       | inactive | none   | 1.25.4  |
| wordpress-importer                  | active   | none   | 0.7     |
| wordpress-seo                       | inactive | none   | 18.5.1  |
+-------------------------------------+----------+--------+---------+
```
```
wp --path=/var/www/stage.creativecommons.org/wp --url=stage.creativecommons.org theme list
```
```
+------------------------------+----------+-----------+-----------+
| name                         | status   | update    | version   |
+------------------------------+----------+-----------+-----------+
| creativecommons-base         | parent   | none      | 2022.03.2 |
| twentytwentytwo              | inactive | available | 1.0       |
| wp-theme-creativecommons.org | active   | none      | 2022.03.2 |
+------------------------------+----------+-----------+-----------+
```

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

For the purposes of this DCO, "license" is equivalent to "license or public domain dedication," and "open source license" is equivalent to "open content license or public domain dedication."
<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
