### PR TITLE
Update Apache2 config for stage.creativecommons.org

### DIFF
--- a/states/apache2/files/creativecommons_org.conf
+++ b/states/apache2/files/creativecommons_org.conf
@@ -18,15 +18,18 @@
     ###########################################################################
     # CC Legal Tools
     # Directory Aliases
-    Alias /status       /var/www/git/cc-legal-tools-data/docs/status
-    Alias /rdf          /var/www/git/cc-legal-tools-data/docs/rdf
-    Alias /publicdomain /var/www/git/cc-legal-tools-data/docs/publicdomain
-    Alias /licenses     /var/www/git/cc-legal-tools-data/docs/licenses
+    Alias /status           /var/www/git/cc-legal-tools-data/docs/status
+    Alias /rdf              /var/www/git/cc-legal-tools-data/docs/rdf
+    Alias /publicdomain     /var/www/git/cc-legal-tools-data/docs/publicdomain
+    Alias /licenses         /var/www/git/cc-legal-tools-data/docs/licenses
+    Alias /cc-legal-tools   /var/www/git/cc-legal-tools-data/docs/cc-legal-tools
     # File Aliases
     Alias /schema.rdf   /var/www/git/cc-legal-tools-data/docs/rdf/schema.rdf
     Alias /ns.html      /var/www/git/cc-legal-tools-data/docs/rdf/ns.html
     Alias /ns           /var/www/git/cc-legal-tools-data/docs/rdf/ns.html
     <Directory /var/www/git/cc-legal-tools-data/docs>
+        # Disable .htaccess (for security and performance)
+        AllowOverride None
         # Also serve HTML files without .html extension
         RewriteCond %{REQUEST_FILENAME}.html -f
         RewriteRule !.*\.html$ %{REQUEST_FILENAME}.html [L]
@@ -44,6 +47,8 @@
     # Platform Toolkit
     Alias /platform/toolkit /var/www/git/mp/docs
     <Directory /var/www/git/mp/docs>
+        # Disable .htaccess (for security and performance)
+        AllowOverride None
         # Redirect .../index.php to .../
         RewriteCond %{REQUEST_FILENAME} "index\.php$" [NC]
         RewriteCond %{REQUEST_FILENAME} !-f
@@ -99,16 +104,17 @@
     # https://codex.wordpress.org/Using_Permalinks
     # Directory Conditions
     RewriteCond %{REQUEST_FILENAME} !-d
-    RewriteCond %{REQUEST_URI} !^/licenses
-    RewriteCond %{REQUEST_URI} !^/publicdomain
-    RewriteCond %{REQUEST_URI} !^/rdf
-    RewriteCond %{REQUEST_URI} !^/status
     RewriteCond %{REQUEST_URI} !^/wp
+    RewriteCond %{REQUEST_URI} !^/status
+    RewriteCond %{REQUEST_URI} !^/rdf
+    RewriteCond %{REQUEST_URI} !^/publicdomain
+    RewriteCond %{REQUEST_URI} !^/licenses
+    RewriteCond %{REQUEST_URI} !^/cc-legal-tools
     # File Conditions
     RewriteCond %{REQUEST_FILENAME} !-f
-    RewriteCond %{REQUEST_URI} !^/ns$
-    RewriteCond %{REQUEST_URI} !^/ns.html$
     RewriteCond %{REQUEST_URI} !^/schema.rdf$
+    RewriteCond %{REQUEST_URI} !^/ns.html$
+    RewriteCond %{REQUEST_URI} !^/ns$
     # Rule
     RewriteRule . /wp/index.php [L]
 
@@ -116,17 +122,18 @@
     # https://codex.wordpress.org/Giving_WordPress_Its_Own_Directory
     # Directory Conditions
     RewriteCond %{REQUEST_FILENAME} !-d
-    RewriteCond %{REQUEST_URI} !^/licenses
-    RewriteCond %{REQUEST_URI} !^/publicdomain
-    RewriteCond %{REQUEST_URI} !^/rdf
-    RewriteCond %{REQUEST_URI} !^/status
-    RewriteCond %{REQUEST_URI} !^/wp-content/
     RewriteCond %{REQUEST_URI} !^/wp/
+    RewriteCond %{REQUEST_URI} !^/wp-content/
+    RewriteCond %{REQUEST_URI} !^/status
+    RewriteCond %{REQUEST_URI} !^/rdf
+    RewriteCond %{REQUEST_URI} !^/publicdomain
+    RewriteCond %{REQUEST_URI} !^/licenses
+    RewriteCond %{REQUEST_URI} !^/cc-legal-tools
     # File Conditions
     RewriteCond %{REQUEST_FILENAME} !-f
-    RewriteCond %{REQUEST_URI} !^/ns$
-    RewriteCond %{REQUEST_URI} !^/ns.html$
     RewriteCond %{REQUEST_URI} !^/schema.rdf$
+    RewriteCond %{REQUEST_URI} !^/ns.html$
+    RewriteCond %{REQUEST_URI} !^/ns$
     # Rule
     RewriteRule ^/(.*)$ /wp/$1
 </VirtualHost>


### PR DESCRIPTION
## Description
Update Apache2 config for `stage.creativecommons.org`:
- Add `/cc-legal-tools` alias
- Disable overrides in static content directories for both security and performance

## Technical details
[AllowOverride Directive - core - Apache HTTP Server Version 2.4](https://httpd.apache.org/docs/current/mod/core.html#allowoverride):
> When this directive is set to `None` and [`AllowOverrideList`](https://httpd.apache.org/docs/current/mod/core.html#allowoverridelist) is set to `None`, [.htaccess](https://httpd.apache.org/docs/current/mod/core.html#accessfilename) files are completely ignored. In this case, the server will not even attempt to read `.htaccess` files in the filesystem.

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

For the purposes of this DCO, "license" is equivalent to "license or public domain dedication," and "open source license" is equivalent to "open content license or public domain dedication."
<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
