### PR TITLE
Update Salt to 3005.1+ds-1 for Debian 10 and later

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,9 +136,10 @@ See [`CONTRIBUTING.md`](CONTRIBUTING.md).
   - Free/Open Source
   - Performance
   - Creative Commons is already using it and staff are familiar with it
-  - Version: `3004.2`
+  - Version: `3005.1`
     - For current targeted minion version, see `minion_target_version` in
       [`pillars/salt/init.sls`](pillars/salt/init.sls)
+    - Debian 9 (Stretch) uses a hardcoded value of `3004.2`
 
 [gitcrypt]: https://www.agwa.name/projects/git-crypt/
 

--- a/pillars/salt/init.sls
+++ b/pillars/salt/init.sls
@@ -1,2 +1,2 @@
 salt:
-  minion_target_version: 3004.2+ds-1
+  minion_target_version: 3005.1+ds-1

--- a/states/salt/init.sls
+++ b/states/salt/init.sls
@@ -12,7 +12,12 @@ include:
       - gnupg
 
 
+{% if grains['osmajorrelease'] < 10 -%}
+# Hardcode SaltStack version for Debian 9 (Stretch) :`(
+{% set salt_version_major = 3004 -%}
+{% else -%}
 {% set salt_version_major = pillar.salt.minion_target_version[0:4] -%}
+{% endif -%}
 {% set os = grains['oscodename'] -%}
 {% set repo_url = ("https://repo.saltproject.io/py3/debian/{}/amd64/{}"
                    .format(grains['osmajorrelease'], salt_version_major)) -%}

--- a/states/salt/minion.sls
+++ b/states/salt/minion.sls
@@ -27,7 +27,12 @@
     - follow_symlinks: False
 
 
+{% if grains['osmajorrelease'] < 10 -%}
+# Hardcode SaltStack version for Debian 9 (Stretch) :`(
+{% set target = "3004.2+ds-1" -%}
+{% else -%}
 {% set target = pillar["salt"]["minion_target_version"] -%}
+{% endif -%}
 {{ sls }} upgrade minion:
   cmd.run:
     - name: nohup /usr/local/sbin/upgrade_minion.sh {{ target }}


### PR DESCRIPTION
## Description
Update Salt to `3005.1+ds-1` for Debian 10 and later (from ~~`3004.2+ds-1`~~, see #181)
- Release Notes
  - [Salt 3005 release notes - Codename Phosphorus](https://docs.saltproject.io/en/master/topics/releases/3005.html)
    > Debian and Raspbian 9 are now EOL, therefore we will no longer be building packages for these platforms.
  - [Salt 3005.1 Release Notes](https://docs.saltproject.io/en/master/topics/releases/3005.1.html)
- Issues
  - impacted by saltstack/salt#62849, but it does not appear to be blocking (appears to only error on install on some hosts)
    ```python
    The minion function caused an exception: Traceback (most recent call last):
      File "/usr/lib/python3/dist-packages/salt/minion.py", line 1912, in _thread_return
        sdata.update(data)
      File "/usr/lib/python3/dist-packages/salt/minion.py", line 1869, in _execute_job_function
        if function_name in self.functions:
      File "/usr/lib/python3/dist-packages/salt/loader/lazy.py", line 149, in __call__
        return self.loader.run(run_func, *args, **kwargs)
      File "/usr/lib/python3/dist-packages/salt/loader/lazy.py", line 1201, in run
        module_name = virtualname
      File "/usr/lib/python3/dist-packages/salt/loader/lazy.py", line 1216, in _run_as
        module_name,
      File "/usr/lib/python3/dist-packages/salt/executors/direct_call.py", line 10, in execute
        return func(*args, **kwargs)
      File "/usr/lib/python3/dist-packages/salt/loader/lazy.py", line 149, in __call__
        return self.loader.run(run_func, *args, **kwargs)
      File "/usr/lib/python3/dist-packages/salt/loader/lazy.py", line 1201, in run
        module_name = virtualname
      File "/usr/lib/python3/dist-packages/salt/loader/lazy.py", line 1216, in _run_as
        module_name,
      File "/usr/lib/python3/dist-packages/salt/modules/state.py", line 1129, in highstate
        orchestration_jid = kwargs.get("orchestration_jid")
      File "/usr/lib/python3/dist-packages/salt/loader/lazy.py", line 149, in __call__
        return self.loader.run(run_func, *args, **kwargs)
      File "/usr/lib/python3/dist-packages/salt/loader/lazy.py", line 1201, in run
        module_name = virtualname
      File "/usr/lib/python3/dist-packages/salt/loader/lazy.py", line 1216, in _run_as
        module_name,
      File "/usr/lib/python3/dist-packages/salt/modules/config.py", line 211, in option
        if value in __opts__:
      File "/usr/lib/python3/dist-packages/salt/loader/context.py", line 81, in __contains__
        return item in self.value()
      File "/usr/lib/python3/dist-packages/salt/loader/context.py", line 72, in value
        return loader.pack[self.name]
    KeyError: '__opts__'
    ```
  - also impacted by saltstack/salt#63602
    - resolved by manually removing old SSH known hosts entries
    - may have been triggered by [We updated our RSA SSH host key | The GitHub Blog](https://github.blog/2023-03-23-we-updated-our-rsa-ssh-host-key/)

## Technical details
First, upgraded `salt-master` host manually:
1. Reviewed currently installed versions:
    ```shell
    dpkg-query -W | fgrep salt
    ```
    ```
    salt-common	3004.2+ds-1
    salt-master	3004.2+ds-1
    salt-minion	3004.2+ds-1
    salt-ssh	3004.2+ds-1
    ```
2. Manually updated URL in `/etc/apt/sources.list.d/saltstack.list`
3. Updated package list
    ```shell
    sudo apt-get update
    ````
4. Verified new package was available
    ```shell
    apt-cache show salt-master
    ```
5. Installed new packages
    ```shell
    sudo apt-get install salt-common salt-master salt-minion salt-ssh
    ```

Per Files changed, we added a condition and hardcoded the Salt version for Debian 9.

Next, All hosts were upgraded via the following process:
1. Updated `minion_target_version` per Files changed
2. Tested changes on all hosts:
    ```shell
    sudo salt \* state.sls salt saltenv=${USER} test=True
    ```
3. Applied changes on all hosts:
    ```shell
    sudo salt \* state.sls salt saltenv=${USER}
    ```
4. Verify:
    ```shell
    sudo salt \* test.version
    ```
5. Updated internal documentation

<!--
## Tests
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->

<!--
## Screenshots
<!-- Add screenshots to show the problem and the solution; or delete this section entirely. -->

## Checklist
<!-- DON'T remove this section or any of the lines. -->
<!-- Leave incomplete or inapplicable lines unchecked. -->
<!-- Replace the [ ] with [x] to check the boxes (there is no space between x and square brackets). -->
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

For the purposes of this DCO, "license" is equivalent to "license or public domain dedication," and "open source license" is equivalent to "open content license or public domain dedication."
<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
