### PR TITLE
Default redirects site config to use redirects.creativecommons.org-0001

### DIFF
--- a/states/nginx/files/redirects_default
+++ b/states/nginx/files/redirects_default
@@ -21,8 +21,8 @@ server {
     listen 443 ssl http2;
     listen [::]:443 ssl http2;
     access_log off;
-    ssl_certificate /etc/letsencrypt/live/redirects.creativecommons.org/fullchain.pem;
-    ssl_certificate_key /etc/letsencrypt/live/redirects.creativecommons.org/privkey.pem;
+    ssl_certificate /etc/letsencrypt/live/redirects.creativecommons.org-0001/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/redirects.creativecommons.org-0001/privkey.pem;
     # Redirect everything to creativecommons.org
     return 301 https://creativecommons.org$request_uri;
 }


### PR DESCRIPTION

## Description
Default redirects site config to use redirects.creativecommons.org-0001
- complete fixes in #207 


## Checklist
<!-- DON'T remove this section or any of the lines. -->
<!-- Leave incomplete or inapplicable lines unchecked. -->
<!-- Replace the [ ] with [x] to check the boxes (there is no space between x and square brackets). -->
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

For the purposes of this DCO, "license" is equivalent to "license or public domain dedication," and "open source license" is equivalent to "open content license or public domain dedication."
<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
