### PR TITLE
norm_wp_perms.sh - make selected chowns recursive

### DIFF
--- a/states/wordpress/files/norm_wp_perms.sh
+++ b/states/wordpress/files/norm_wp_perms.sh
@@ -37,6 +37,13 @@ headertwo() {
 
 #### MAIN #############################################################
 
+# Require sudo
+if (( ${UID} != 0 ))
+then
+    error_exit 'Must be root (invoke with sudo)'
+fi
+return 0
+
 # Find WordPress installations
 WP_CONFIGS=$(find /var/www -maxdepth 2 -type f -name 'wp-config.php' \
                 2>/dev/null \

--- a/states/wordpress/files/norm_wp_perms.sh
+++ b/states/wordpress/files/norm_wp_perms.sh
@@ -42,7 +42,6 @@ if (( ${UID} != 0 ))
 then
     error_exit 'Must be root (invoke with sudo)'
 fi
-return 0
 
 # Find WordPress installations
 WP_CONFIGS=$(find /var/www -maxdepth 2 -type f -name 'wp-config.php' \

--- a/states/wordpress/files/norm_wp_perms.sh
+++ b/states/wordpress/files/norm_wp_perms.sh
@@ -40,7 +40,8 @@ headertwo() {
 # Require sudo
 if (( ${UID} != 0 ))
 then
-    error_exit 'Must be root (invoke with sudo)'
+    echo 'Must be root (invoke with sudo)' 1>&2
+    exit 1
 fi
 
 # Find WordPress installations

--- a/states/wordpress/files/norm_wp_perms.sh
+++ b/states/wordpress/files/norm_wp_perms.sh
@@ -41,20 +41,23 @@ headertwo() {
 WP_CONFIGS=$(find /var/www -maxdepth 2 -type f -name 'wp-config.php' \
                 2>/dev/null \
                 || true)
-for _wp_config in ${WP_CONFIGS}; do
+for _wp_config in ${WP_CONFIGS}
+do
     WP_DIR="${_wp_config%/*}"
     headerone 'Normalzing permissions on WordPress top directory:'
     # composer.json file
     TARGET="${WP_DIR}/composer.json"
     headertwo "${TARGET}"
-    if [[ -f "${TARGET}" ]]; then
+    if [[ -f "${TARGET}" ]]
+    then
         chgrp -ch webdev "${TARGET}"
         chmod -c 00664 "${TARGET}"
     fi
     # backup directory
     TARGET="${WP_DIR}/backup"
     headertwo "${TARGET}"
-    if [[ -d "${TARGET}" ]]; then
+    if [[ -d "${TARGET}" ]]
+    then
         chown -ch root "${TARGET}"
         chgrp -chR webdev "${TARGET}"
         chmod -c 2770 "${TARGET}"
@@ -66,14 +69,16 @@ for _wp_config in ${WP_CONFIGS}; do
     # vendor symlink - unnecessary aesthetics ¯\_(ツ)_/¯
     TARGET="${WP_DIR}/vendor"
     headertwo "$(printf '%-43s (symlink)\n' "${TARGET}")"
-    if [[ -L "${TARGET}" ]]; then
-        chown -ch composer:webdev "${TARGET}"
+    if [[ -L "${TARGET}" ]]
+    then
+        chown -chR composer:webdev "${TARGET}"
     fi
     # wp directory
     TARGET="${WP_DIR}/wp"
     headertwo "${TARGET}"
-    if [[ -d "${TARGET}" ]]; then
-        chown -ch composer:webdev "${TARGET}"
+    if [[ -d "${TARGET}" ]]
+    then
+        chown -chR composer:webdev "${TARGET}"
         chmod -c 2775 "${TARGET}"
         /usr/bin/find "${TARGET}" \
             -type d -exec chmod -c 2775 {} + \
@@ -83,11 +88,13 @@ for _wp_config in ${WP_CONFIGS}; do
     # wp-content directory
     TARGET="${WP_DIR}/wp-content"
     headertwo "${TARGET}"
-    if [[ -d "${TARGET}" ]]; then
+    if [[ -d "${TARGET}" ]]
+    then
         chown -ch root:root "${TARGET}"
         chmod -c 00555 "${TARGET}"
         # wp-content subdirectories
-        for _dir in $(/usr/bin/find "${TARGET}" -maxdepth 1 -type d); do
+        for _dir in $(/usr/bin/find "${TARGET}" -maxdepth 1 -type d)
+        do
             TARGET_USER=composer
             TARGET_GROUP=webdev
             TARGET_FMODE=00664


### PR DESCRIPTION
## Fixes
Fixes creativecommons/tech-support#1029 (private repo)

## Description
- `norm_wp_perms.sh`
  - make selected chowns recursive
  - add invoke with sudo warning
  - update syntax to remove `;`
- related to https://github.com/creativecommons/tech-support/issues/1029

<!--
## Technical details
-->

<!--
## Tests
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete this section entirely. -->

<!--
## Screenshots
<!-- Add screenshots to show the problem and the solution; or delete this section entirely. -->

## Checklist
<!-- DON'T remove this section or any of the lines. -->
<!-- Leave incomplete or inapplicable lines unchecked. -->
<!-- Replace the [ ] with [x] to check the boxes (there is no space between x and square brackets). -->
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

For the purposes of this DCO, "license" is equivalent to "license or public domain dedication," and "open source license" is equivalent to "open content license or public domain dedication."
<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
