### PR TITLE
update SaltStack configuration files for ccorg staging server provisioning

### DIFF
--- a/pillars/infra/us-east-2/init.sls
+++ b/pillars/infra/us-east-2/init.sls
@@ -1,8 +1,8 @@
 infra:
   us-east-2:
     # url: https://wiki.debian.org/Cloud/AmazonEC2Image/Bullseye
-    debian_ami_name: debian-11-amd64-20230124-1270
-    debian_ami_id: ami-0f35413f664528e13
+    debian_ami_name: debian-11-amd64-20230601-1398
+    debian_ami_id: ami-0e50c2608aa71804a
     instance_iam_role: ec2_core_iam_role
     kms_key_id_storage: storage_core_kmskey
     vendor: aws

--- a/states/wordpress/ccorg.sls
+++ b/states/wordpress/ccorg.sls
@@ -80,8 +80,9 @@
     - fetch_tags: False
     - require:
       - file: {{ sls }} {{ GIT }} directory
-
-
+ 
+{#- commented as it changes all file permissions leading to issue while 
+ #  updating the repo
 {{ sls }} {{ repo }} permissions:
   file.directory:
     - name: {{ GIT }}/{{ repo }}
@@ -93,4 +94,5 @@
       - group
     - require:
       - git: {{ sls }} {{ repo }} repo
+#}
 {%- endfor %}

--- a/states/wordpress/files/ccorg-composer.json
+++ b/states/wordpress/files/ccorg-composer.json
@@ -21,35 +21,16 @@
     {
       "type": "composer",
       "url": "https://wpackagist.org"
-    },
-    {
-      "no-api": true,
-      "type": "vcs",
-      "url": "https://github.com/creativecommons/creativecommons-base"
-    },
-    {
-      "no-api": true,
-      "type": "vcs",
-      "url": "https://github.com/creativecommons/wp-plugin-creativecommons-website"
-    },
-    {
-      "no-api": true,
-      "type": "vcs",
-      "url": "https://github.com/creativecommons/wp-theme-creativecommons.org"
     }
   ],
   "require": {
-    "composer/installers": "^1.0",
-    "creativecommons/wp-plugin-creativecommons-website": "0.5.0",
-    "creativecommons/wp-theme-creativecommons.org": "2022.03.2",
-    "johnpbloch/wordpress": "5.9.3",
-    "wpackagist-plugin/ultimate-addons-for-gutenberg": "1.25.4",
-    "wpackagist-plugin/wordpress-importer": "0.7",
-    "wpackagist-plugin/wordpress-seo": "18.5.1"
+    "composer/installers": "^2.2",
+    "johnpbloch/wordpress": "6.2",
+    "wpackagist-plugin/wordpress-importer": "0.8.1"
   },
   "require-dev": {
-    "wpackagist-plugin/debug-bar": "1.1.2",
-    "wpackagist-plugin/debug-bar-actions-and-filters-addon": "1.5.4"
+    "wpackagist-plugin/debug-bar": "1.1.4",
+    "wpackagist-plugin/debug-bar-actions-and-filters-addon": "1.5.5"
   },
   "type": "project"
 }


### PR DESCRIPTION
## Description
- update wordpress plugins and versions
- update ccorg.sls file 
- update debian ami image
- related to [provision ccorg](https://github.com/creativecommons/tech-support/issues/1034)(private repo)

## Checklist
<!-- DON'T remove this section or any of the lines. -->
<!-- Leave incomplete or inapplicable lines unchecked. -->
<!-- Replace the [ ] with [x] to check the boxes (there is no space between x and square brackets). -->
- [X] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

For the purposes of this DCO, "license" is equivalent to "license or public domain dedication," and "open source license" is equivalent to "open content license or public domain dedication."
<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
