### PR TITLE
update wordpress redirection plugin and vocab theme

### DIFF
--- a/states/wordpress/files/index-composer.json
+++ b/states/wordpress/files/index-composer.json
@@ -47,7 +47,7 @@
     "reyhoun/acf-menu-chooser": "1.1",
     "wpackagist-plugin/advanced-custom-fields": "6.1.8",
     "wpackagist-plugin/classic-editor": "1.6.3",
-    "wpackagist-plugin/redirection": "4.9.2",
+    "wpackagist-plugin/redirection": "5.3.10",
     "wpackagist-plugin/tablepress": "1.14",
     "wpackagist-plugin/wordfence": "7.10.3",
     "wpackagist-plugin/wordpress-importer": "0.8.1",

--- a/states/wordpress/files/index-composer.json
+++ b/states/wordpress/files/index-composer.json
@@ -42,7 +42,7 @@
   ],
   "require": {
     "composer/installers": "^2.2",
-    "creativecommons/vocabulary-theme": "0.12.0",
+    "creativecommons/vocabulary-theme": "0.13.0",
     "johnpbloch/wordpress": "6.2",
     "reyhoun/acf-menu-chooser": "1.1",
     "wpackagist-plugin/advanced-custom-fields": "6.1.8",


### PR DESCRIPTION
## Description

- update wordpress redirection plugin from 4.9.2 to 5.3.10
-  related to https://github.com/creativecommons/index-dev-env/pull/35
- update vocabulary theme to 0.13.0
- related to https://github.com/creativecommons/vocabulary-theme/pull/22 and https://github.com/creativecommons/index-dev-env/pull/36

## Tests
- tested on `index__stage__us-east-2` & `index__prod__us-east-2` servers and the result is as expected.

## Checklist
<!-- DON'T remove this section or any of the lines. -->
<!-- Leave incomplete or inapplicable lines unchecked. -->
<!-- Replace the [ ] with [x] to check the boxes (there is no space between x and square brackets). -->
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

For the purposes of this DCO, "license" is equivalent to "license or public domain dedication," and "open source license" is equivalent to "open content license or public domain dedication."
<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
