### PR TITLE
add "licenses" PDM redirect

### DIFF
--- a/states/apache2/files/index.conf
+++ b/states/apache2/files/index.conf
@@ -43,6 +43,7 @@
         RewriteRule (.*/rdf$) $1 [T=application/rdf+xml]
     </Directory>
     Include /var/www/git/cc-legal-tools-data/config/language-redirects
+    RedirectPermanent  /licenses/mark/1.0  /publicdomain/mark/1.0
 
     ###########################################################################
     # Chooser


### PR DESCRIPTION
## Fixes
Fixes creativecommons/cc-legal-tools-app#316
- creativecommons/cc-legal-tools-app#316

## Description
add "licenses" PDM redirect

Change has been applied to stage, but not prod.

<!--
## Technical details
-->

## Tests
```shell
http -h https://[REDACTED]:[REDACTED]@stage.creativecommons.org/licenses/mark/1.0/deed
```
```
HTTP/1.1 301 Moved Permanently
CF-Cache-Status: BYPASS
CF-RAY: 8147b08fcacc521a-LAX
Connection: keep-alive
Content-Type: text/html; charset=iso-8859-1
Date: Wed, 11 Oct 2023 14:10:59 GMT
Location: https://stage.creativecommons.org/publicdomain/mark/1.0/deed
Server: cloudflare
Transfer-Encoding: chunked
Vary: Accept-Encoding
```

<!--
## Screenshots
<!-- Add screenshots to show the problem and the solution; or delete this section entirely. -->

## Checklist
<!-- DON'T remove this section or any of the lines. -->
<!-- Leave incomplete or inapplicable lines unchecked. -->
<!-- Replace the [ ] with [x] to check the boxes (there is no space between x and square brackets). -->
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

For the purposes of this DCO, "license" is equivalent to "license or public domain dedication," and "open source license" is equivalent to "open content license or public domain dedication."
<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
