### PR TITLE
add allow_plugin, no_api section and update wp plugin versions 

### DIFF
--- a/states/wordpress/files/podcast-composer.json
+++ b/states/wordpress/files/podcast-composer.json
@@ -1,34 +1,48 @@
 {
-    "name":"creativecommons/wordpress-podcast",
-    "description":"Creative Commons Podcast WordPress Site via Composer",
-    "authors": [
-        {
-            "name":"Creative Commons",
-            "homepage":"https://github.com/creativecommons/sre-salt-prime"
-        }
-    ],
-    "type": "project",
-    "repositories": [
-        {
-            "type":"composer",
-            "url":"https://wpackagist.org"
-        }
-    ],
-    "config": {
-        "vendor-dir":"wp-content/vendor"
-    },
-    "require": {
-        "composer/installers":"1.6",
-        "johnpbloch/wordpress":"5.0.3",
-        "wpackagist-plugin/wordfence":"7.2.1",
-        "wpackagist-plugin/wordpress-seo":"9.6",
-        "wpackagist-theme/twentynineteen":"1.2"
-    },
-    "require-dev": {
-        "wpackagist-plugin/debug-bar":"1.0",
-        "wpackagist-plugin/debug-bar-actions-and-filters-addon":"1.5.4"
-    },
-    "extra": {
-        "wordpress-install-dir":"wp"
+  "authors": [
+    {
+      "homepage": "https://github.com/creativecommons/sre-salt-prime",
+      "name": "Creative Commons"
     }
+  ],
+  "config": {
+    "allow-plugins": {
+      "composer/installers": true,
+      "johnpbloch/wordpress-core-installer": true
+    },
+    "vendor-dir": "wp-content/vendor"
+  },
+  "description": "Creative Commons Podcast WordPress Site via Composer",
+  "extra": {
+    "wordpress-install-dir": "wp"
+  },
+  "name": "creativecommons/wordpress-podcast",
+  "repositories": [
+    {
+      "type": "composer",
+      "url": "https://wpackagist.org"
+    },
+    {
+      "no-api": true,
+      "type": "vcs",
+      "url": "https://github.com/qtranslate/qtranslate-xt"
+    },
+    {
+      "no-api": true,
+      "type": "vcs",
+      "url": "https://github.com/creativecommons/wp-theme-cctoolkit"
+    }
+  ],
+  "require": {
+    "composer/installers": "2.2",
+    "johnpbloch/wordpress": "6.4",
+    "wpackagist-plugin/wordfence": "7.4.10",
+    "wpackagist-plugin/wordpress-seo": "21.6",
+    "wpackagist-theme/twentynineteen": "1.2"
+  },
+  "require-dev": {
+    "wpackagist-plugin/debug-bar": "1.0.1",
+    "wpackagist-plugin/debug-bar-actions-and-filters-addon": "1.5.4"
+  },
+  "type": "project"
 }


### PR DESCRIPTION
## Description

Add `allow_plugin` section, `no_api` repository for `qtranslate-xt` & `wp-theme-cctoolkit`, and update `wordpress` plugin versions 
- related to https://github.com/creativecommons/tech-support/issues/1067


## Tests
tested on `podcast__prod__us-east-2` and now, website is loading as expected 


## Checklist
<!-- DON'T remove this section or any of the lines. -->
<!-- Leave incomplete or inapplicable lines unchecked. -->
<!-- Replace the [ ] with [x] to check the boxes (there is no space between x and square brackets). -->
- [ ] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [ ] My pull request targets the *default* branch of the repository (`main` or `master`).
- [ ] My commit messages follow [best practices][best_practices].
- [ ] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [ ] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

For the purposes of this DCO, "license" is equivalent to "license or public domain dedication," and "open source license" is equivalent to "open content license or public domain dedication."
<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
