### PR TITLE
Ensure CC Legal Tools URLs are lowercase

### DIFF
--- a/states/apache2/files/index.conf
+++ b/states/apache2/files/index.conf
@@ -31,6 +31,11 @@
     Alias /schema.rdf   /var/www/git/cc-legal-tools-data/docs/rdf/schema.rdf
     Alias /ns.html      /var/www/git/cc-legal-tools-data/docs/rdf/ns.html
     Alias /ns           /var/www/git/cc-legal-tools-data/docs/rdf/ns.html
+    # Ensure lowercase
+    RewriteMap lowercase int:tolower
+    RewriteCond %{REQUEST_URI} ^/(licenses|publicdomain) [NC]
+    RewriteCond %{REQUEST_URI} [A-Z]
+    RewriteRule ^(.*)$ ${lowercase:$1} [R=301,L]
     <Directory /var/www/git/cc-legal-tools-data/docs>
         # Disable .htaccess (for security and performance)
         AllowOverride None


### PR DESCRIPTION
## Description
Ensure CC Legal Tools URLs are lowercase

This moves and improves the lowercase rewrites to prepare for moving the generated redirects/rewrites to within the directory context.

## Technical details
- [mod_rewrite - Apache HTTP Server Version 2.4](https://httpd.apache.org/docs/2.4/mod/mod_rewrite.html)
- In testing, this method was more robust than alternative:
    ```apache
            RewriteCond %{REQUEST_URI} ^/(licenses|publicdomain) [NC]
            RewriteCond expr "tolower(%{REQUEST_URI}) =~ /(.*)/"
            RewriteRule [A-Z] %1 [R=301,L]
    ```

## Tests
Tested in development environment:
- creativecommons/index-dev-env#72

<!--
## Screenshots
<!-- Add screenshots to show the problem and the solution; or comment out this section entirely. -->

## Checklist
<!-- DON'T remove this section or any of the lines. -->
<!-- Leave incomplete or inapplicable lines unchecked. -->
<!-- Replace the [ ] with [x] to check the boxes (there is no space between x and square brackets). -->
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- YOU MUST READ AND UNDERSTAND THE FOLLOWING ATTESTATION. -->
<!-- -->
<!-- Be aware that copying and pasting from discussion sites or generative AI isn't allowed under this DCO. -->

For the purposes of this DCO, "license" is equivalent to "license or public domain dedication," and "open source license" is equivalent to "open content license or public domain dedication."
<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
