### PR TITLE
Redirect chooser PDM to public wiki

### DIFF
--- a/states/apache2/files/index.conf
+++ b/states/apache2/files/index.conf
@@ -82,10 +82,10 @@
 #        RewriteRule .*\.php "-" [F,L]
 #    </Directory>
     RedirectPermanent /chooser              /choose
-    RedirectPermanent /choose/zero          /choose
+    RedirectTemp /choose/mark/  https://wiki.creativecommons.org/wiki/PDM_FAQ
+    RedirectTemp /choose        https://chooser-beta.creativecommons.org
     RedirectPermanent /choose/publicdomain  /choose
-    RedirectTemp /choose https://chooser-beta.creativecommons.org
-
+    RedirectPermanent /choose/zero /choose
     ###########################################################################
     # FAQ
     Alias /faq /var/www/git/faq/faq

--- a/states/apache2/files/index.conf
+++ b/states/apache2/files/index.conf
@@ -86,6 +86,7 @@
     RedirectTemp /choose        https://chooser-beta.creativecommons.org
     RedirectPermanent /choose/publicdomain  /choose
     RedirectPermanent /choose/zero /choose
+
     ###########################################################################
     # FAQ
     Alias /faq /var/www/git/faq/faq

--- a/states/apache2/files/index.conf
+++ b/states/apache2/files/index.conf
@@ -81,11 +81,11 @@
 #        # Deny access to PHP files (content should be only static files)
 #        RewriteRule .*\.php "-" [F,L]
 #    </Directory>
-    RedirectTemp /choose/mark/  https://wiki.creativecommons.org/wiki/PDM_FAQ
-    RedirectTemp /choose        https://chooser-beta.creativecommons.org
-    RedirectPermanent /choose/zero /choose
-    RedirectPermanent /choose/publicdomain  /choose
-    RedirectPermanent /chooser              /choose
+    RedirectTemp  /chooser              https://chooser-beta.creativecommons.org 
+    RedirectTemp  /choose/zero          https://chooser-beta.creativecommons.org 
+    RedirectTemp  /choose/publicdomain  https://chooser-beta.creativecommons.org
+    RedirectTemp  /choose/mark/  https://wiki.creativecommons.org/wiki/PDM_FAQ
+    RedirectTemp  /choose               https://chooser-beta.creativecommons.org 
 
     ###########################################################################
     # FAQ

--- a/states/apache2/files/index.conf
+++ b/states/apache2/files/index.conf
@@ -81,11 +81,11 @@
 #        # Deny access to PHP files (content should be only static files)
 #        RewriteRule .*\.php "-" [F,L]
 #    </Directory>
-    RedirectPermanent /chooser              /choose
     RedirectTemp /choose/mark/  https://wiki.creativecommons.org/wiki/PDM_FAQ
     RedirectTemp /choose        https://chooser-beta.creativecommons.org
-    RedirectPermanent /choose/publicdomain  /choose
     RedirectPermanent /choose/zero /choose
+    RedirectPermanent /choose/publicdomain  /choose
+    RedirectPermanent /chooser              /choose
 
     ###########################################################################
     # FAQ


### PR DESCRIPTION
## Description
- update index.conf
- redirect chooser PDM to public wiki
- related to https://github.com/creativecommons/index-dev-env/pull/74 

## Tests
- tested on staging server

Before PR:
```
http --all --follow --headers https://stage.creativecommons.org/choose/mark/
HTTP/1.1 302 Found
CF-Cache-Status: DYNAMIC
CF-RAY: 88f22906cea7abbb-YYZ
Connection: keep-alive
Content-Type: text/html; charset=iso-8859-1
Date: Wed, 05 Jun 2024 18:17:34 GMT
Location: https://stage.creativecommons.org/choose/mark/
Server: cloudflare
Transfer-Encoding: chunked

HTTP/1.1 302 Found
CF-Cache-Status: DYNAMIC
CF-RAY: 88f229077fb1ac51-YYZ
Connection: keep-alive
Content-Type: text/html; charset=iso-8859-1
Date: Wed, 05 Jun 2024 18:17:34 GMT
Location: https://chooser-beta.creativecommons.org/mark/
Server: cloudflare
Transfer-Encoding: chunked

HTTP/1.1 404 Not Found
Accept-Ranges: bytes
Access-Control-Allow-Origin: *
Age: 0
Connection: keep-alive
Content-Encoding: gzip
Content-Length: 5254
Content-Security-Policy: default-src 'none'; style-src 'unsafe-inline'; img-src data:; connect-src 'self'
Content-Type: text/html; charset=utf-8
Date: Wed, 05 Jun 2024 18:17:34 GMT
ETag: W/"64d39a40-24a3"
Server: GitHub.com
Vary: Accept-Encoding
Via: 1.1 varnish
X-Cache: MISS
X-Cache-Hits: 0
X-Fastly-Request-ID: e94467b9e850c1a68cf7ca8e7a6c635d398a7276
X-GitHub-Request-Id: E8EC:F4304:42A9107:5044572:6660ABBE
X-Served-By: cache-yyz4569-YYZ
X-Timer: S1717611455.741602,VS0,VE27
x-origin-cache: HIT
x-proxy-cache: MISS
```

After PR:
```
http --all --follow --headers https://stage.creativecommons.org/choose/mark/
HTTP/1.1 302 Found
CF-Cache-Status: DYNAMIC
CF-RAY: 88f22e2f4ea1ab3e-YYZ
Connection: keep-alive
Content-Type: text/html; charset=iso-8859-1
Date: Wed, 05 Jun 2024 18:21:05 GMT
Location: https://wiki.creativecommons.org/wiki/PDM_FAQ
Server: cloudflare
Transfer-Encoding: chunked

HTTP/1.1 200 OK
CF-Cache-Status: DYNAMIC
CF-RAY: 88f22e2ffc2bac88-YYZ
Cache-Control: private, must-revalidate, max-age=0
Connection: keep-alive
Content-Encoding: gzip
Content-Language: en
Content-Type: text/html; charset=UTF-8
Date: Wed, 05 Jun 2024 18:21:06 GMT
Expires: Thu, 01 Jan 1970 00:00:00 GMT
Last-Modified: Wed, 22 May 2024 08:29:07 GMT
Server: cloudflare
Transfer-Encoding: chunked
Vary: Accept-Encoding,Cookie
X-Content-Type-Options: nosniff
```


## Checklist
<!-- DON'T remove this section or any of the lines. -->
<!-- Leave incomplete or inapplicable lines unchecked. -->
<!-- Replace the [ ] with [x] to check the boxes (there is no space between x and square brackets). -->
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- YOU MUST READ AND UNDERSTAND THE FOLLOWING ATTESTATION. -->
<!-- -->
<!-- Be aware that copying and pasting from discussion sites or generative AI isn't allowed under this DCO. -->

For the purposes of this DCO, "license" is equivalent to "license or public domain dedication," and "open source license" is equivalent to "open content license or public domain dedication."
<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
