### PR TITLE
Add `upgrade-temp-backup` directory in `wp-content`

### DIFF
--- a/states/wordpress/init.sls
+++ b/states/wordpress/init.sls
@@ -133,9 +133,9 @@ include:
       - composer: {{ sls }} composer update
 
 
-{{ sls }} dir wp-content/upgrade-temp-back:
+{{ sls }} dir wp-content/upgrade-temp-backup:
     file.directory:
-      - name: {{ DOCROOT }}/wp-content/upgrade-temp-back
+      - name: {{ DOCROOT }}/wp-content/upgrade-temp-backup
       - mode: '2775'
       - group: webdev
       - require:
@@ -144,13 +144,13 @@ include:
         - composer: {{ sls }} composer update
 
 {%- for dir in ["plugins", "themes"] %}
-{{ sls }} dir wp-content/upgrade-temp-back/{{ dir }}:
+{{ sls }} dir wp-content/upgrade-temp-backup/{{ dir }}:
     file.directory:
-      - name: {{ DOCROOT }}/wp-content/upgrade-temp-back/{{ dir }}
+      - name: {{ DOCROOT }}/wp-content/upgrade-temp-backup/{{ dir }}
       - mode: '2775'
       - group: webdev
       - require:
-        - file: {{ sls }} dir wp-content/upgrade-temp-back
+        - file: {{ sls }} dir wp-content/upgrade-temp-backup
       - require_in:
         - composer: {{ sls }} composer update
 {%- endfor %}

--- a/states/wordpress/init.sls
+++ b/states/wordpress/init.sls
@@ -15,10 +15,6 @@
 {% set ADMIN_USER = salt.pillar.get("wordpress:admin_user", false) -%}
 {% set ADMIN_EMAIL = salt.pillar.get("wordpress:admin_email", false) -%}
 {% set GF_KEY = salt.pillar.get("wordpress:gf_key", false) -%}
-{% set WPCLI = "/usr/local/bin/wp --quiet --no-color --require=/opt/wp-cli/silence.php" -%}
-{% set wp_version = salt['cmd.run'](WPCLI + " core version") | float %}
-
-
 
 
 include:
@@ -136,8 +132,6 @@ include:
     - require_in:
       - composer: {{ sls }} composer update
 
-{% if wp_version >= 6.3 %}
-
 
 {{ sls }} dir wp-content/upgrade-temp-back:
     file.directory:
@@ -160,7 +154,7 @@ include:
       - require_in:
         - composer: {{ sls }} composer update
 {%- endfor %}
-{% endif %}
+
 
 {%- if GF_KEY %}
 


### PR DESCRIPTION
## Fixes
- Fixes #287  by @Shafiya-Heena 

## Description
- update init.sls to create `upgrade-temp-backup` dir in `wp-content`
- update init.sls to create `plugins` and `themes` in `upgrade-temp-backup` dir


## Tests
- tested on `index__stage__us-east-2`


## Checklist
<!-- DON'T remove this section or any of the lines. -->
<!-- Leave incomplete or inapplicable lines unchecked. -->
<!-- Replace the [ ] with [x] to check the boxes (there is no space between x and square brackets). -->
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- YOU MUST READ AND UNDERSTAND THE FOLLOWING ATTESTATION. -->
<!-- -->
<!-- Be aware that copying and pasting from discussion sites or generative AI isn't allowed under this DCO. -->

For the purposes of this DCO, "license" is equivalent to "license or public domain dedication," and "open source license" is equivalent to "open content license or public domain dedication."
<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
