### PR TITLE
update apache2 redirects for new chooser page

### DIFF
--- a/states/apache2/files/index.conf
+++ b/states/apache2/files/index.conf
@@ -81,12 +81,8 @@
 #        # Deny access to PHP files (content should be only static files)
 #        RewriteRule .*\.php "-" [F,L]
 #    </Directory>
-    RedirectTemp  /chooser              https://chooser-beta.creativecommons.org
-    RedirectTemp  /choose/zero          https://chooser-beta.creativecommons.org
-    RedirectTemp  /choose/publicdomain  https://chooser-beta.creativecommons.org
     RedirectTemp  /choose/mark/  https://wiki.creativecommons.org/wiki/PDM_FAQ
     RedirectTemp  /choose/mark   https://wiki.creativecommons.org/wiki/PDM_FAQ
-    RedirectTemp  /choose               https://chooser-beta.creativecommons.org
 
     ###########################################################################
     # FAQ
@@ -173,7 +169,7 @@
     RewriteCond %{REQUEST_URI} !^/platform/toolkit(/|$)
     RewriteCond %{REQUEST_URI} !^/licen[cs]es(/|$)
     RewriteCond %{REQUEST_URI} !^/faq(/|$)
-    RewriteCond %{REQUEST_URI} !^/choose(/|$)
+    RewriteCond %{REQUEST_URI} !^/choose/mark(/|$)
     RewriteCond %{REQUEST_URI} !^/cc-legal-tools(/|$)
     # File Conditions
     RewriteCond %{REQUEST_FILENAME} !-f
@@ -195,7 +191,7 @@
     RewriteCond %{REQUEST_URI} !^/platform/toolkit(/|$)
     RewriteCond %{REQUEST_URI} !^/licen[cs]es(/|$)
     RewriteCond %{REQUEST_URI} !^/faq(/|$)
-    RewriteCond %{REQUEST_URI} !^/choose(/|$)
+    RewriteCond %{REQUEST_URI} !^/choose/mark(/|$)
     RewriteCond %{REQUEST_URI} !^/cc-legal-tools(/|$)
     # File Conditions
     RewriteCond %{REQUEST_FILENAME} !-f


### PR DESCRIPTION
## Description
- related to https://github.com/creativecommons/tech-support/issues/1270
- removed/deleted the redirect rules in `index.conf` file
- tested/verified that `/chooser` and `/choose` is working as expected 
- confirmed that `/choose/mark` is loading at PDM_FAQ

## Tests
- tested on `index__stage__us-east-2`

## Checklist
<!-- DON'T remove this section or any of the lines. -->
<!-- Leave incomplete or inapplicable lines unchecked. -->
<!-- Replace the [ ] with [x] to check the boxes (there is no space between x and square brackets). -->
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- YOU MUST READ AND UNDERSTAND THE FOLLOWING ATTESTATION. -->
<!-- -->
<!-- Be aware that copying and pasting from discussion sites or generative AI isn't allowed under this DCO. -->

For the purposes of this DCO, "license" is equivalent to "license or public domain dedication," and "open source license" is equivalent to "open content license or public domain dedication."
<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
