### PR TITLE
Forbid wp-config-sample.php

### DIFF
--- a/states/apache2/files/index.conf
+++ b/states/apache2/files/index.conf
@@ -149,6 +149,9 @@
     <FilesMatch "^[.]?wp-config[.]php">
         Require all denied
     </FilesMatch>
+    <Files "wp-config-sample.php">
+        Require all denied
+    </Files>
 
     # Default Index
     RewriteRule ^(/)?$ /wp/index.php [L]

--- a/states/apache2/files/wordpress_composer.conf
+++ b/states/apache2/files/wordpress_composer.conf
@@ -39,6 +39,9 @@
     <FilesMatch "^[.]?wp-config[.]php">
         Require all denied
     </FilesMatch>
+    <Files "wp-config-sample.php">
+        Require all denied
+    </Files>
 
     # Plugin Restrictions: Admin Menu Editor
     <Directory {{ DOCROOT }}/wp-content/plugins/admin-menu-editor/includes>


### PR DESCRIPTION
## Description
Forbid `wp-config-sample.php`

(Access to this file shouldn't have any more impact than an error log entry, but better to deny access.)


## Technical details
- [`<Files>` Directive - core - Apache HTTP Server Version 2.4](https://httpd.apache.org/docs/current/mod/core.html#files)

## Tests
### Before
Command:
```shell
http --all --follow --headers --auth [REDACTED]:[REDACTED] \
    "https://stage.creativecommons.org/wp-config-sample.php?$(date +%s)"
```
Output
```http
HTTP/1.1 500 Internal Server Error
CF-RAY: 959711230df1bac4-MXP
Cache-Control: no-cache, must-revalidate, max-age=0
Cf-Cache-Status: DYNAMIC
Connection: keep-alive
Content-Type: text/html; charset=UTF-8
Date: Thu, 03 Jul 2025 14:28:01 GMT
Expires: Wed, 11 Jan 1984 05:00:00 GMT
Server: cloudflare
Transfer-Encoding: chunked
```

### After
Command:
```shell
http --all --follow --headers --auth [REDACTED]:[REDACTED] \
    "https://stage.creativecommons.org/wp-config-sample.php?$(date +%s)"
```
Output
```http
HTTP/1.1 403 Forbidden
CF-RAY: 9597193aa964b260-MXP
Cf-Cache-Status: DYNAMIC
Connection: keep-alive
Content-Encoding: gzip
Content-Type: text/html; charset=iso-8859-1
Date: Thu, 03 Jul 2025 14:33:32 GMT
Server: cloudflare
Transfer-Encoding: chunked
```

<!--
## Screenshots
<!-- Add screenshots to show the problem and the solution; or comment out this section entirely. -->

## Checklist
<!-- DON'T remove this section or any of the lines. -->
<!-- Leave incomplete or inapplicable lines unchecked. -->
<!-- Replace the [ ] with [x] to check the boxes (there is no space between x and square brackets). -->
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- YOU MUST READ AND UNDERSTAND THE FOLLOWING ATTESTATION. -->
<!-- -->
<!-- Be aware that copying and pasting from discussion sites or generative AI isn't allowed under this DCO. -->

For the purposes of this DCO, "license" is equivalent to "license or public domain dedication," and "open source license" is equivalent to "open content license or public domain dedication."
<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
