### PR TITLE
Replace redirect to Slack Community Inviter with redirct to Zulip login

### DIFF
--- a/pillars/5_HST__POD/redirects__core.sls
+++ b/pillars/5_HST__POD/redirects__core.sls
@@ -107,7 +107,7 @@ nginx:
       dst: creativecommons.pl
     - crt: redirects.creativecommons.org-0001
       src: slack-signup.creativecommons.org
-      dst: communityinviter.com/apps/creativecommons/cc
+      dst: creativecommons.zulipchat.com/login/
       ignore_request_uri: true
     - crt: redirects.creativecommons.org-0001
       src: support.creativecommons.org


### PR DESCRIPTION
## Description
Replace redirect to Slack Community Inviter with redirct to Zulip login.

Changes are live in production.

## Technical details
Historical context:
- #202 

## Tests
### Before changes
Command:
```shell
http --all --follow --headers https://slack-signup.creativecommons.org/
```
Output:
```http
HTTP/1.1 301 Moved Permanently
CF-RAY: 9832e539290898b5-MXP
Connection: keep-alive
Content-Type: text/html
Date: Mon, 22 Sep 2025 15:39:30 GMT
Server: cloudflare
Transfer-Encoding: chunked
cf-cache-status: DYNAMIC
location: https://communityinviter.com/apps/creativecommons/cc
strict-transport-security: max-age=15768000
x-content-type-options: nosniff
x-frame-options: deny
x-xss-protection: 1; mode=block

HTTP/1.1 200 OK
Access-Control-Allow-Credentials: true
Access-Control-Allow-Headers: X-Requested-With,content-type
Access-Control-Allow-Methods: GET, POST, OPTIONS, PUT, PATCH, DELETE
Access-Control-Allow-Origin: *
CF-RAY: 9832e53d4d475238-MXP
Connection: keep-alive
Content-Encoding: gzip
Content-Type: text/html; charset=utf-8
Date: Mon, 22 Sep 2025 15:39:30 GMT
Nel: {"report_to":"cf-nel","success_fraction":0.0,"max_age":604800}
Report-To: {"group":"cf-nel","max_age":604800,"endpoints":[{"url":"https://a.nel.cloudflare.com/report/v4?s=oEMmQWMMBAHT8Fg0rOKUvqZhkbd9E8t1xtwhVWkzQyc3u16XXdaReRf8HhdX8mCDJMdodSt804I8vU8LKusVOlK0HmUUaWJ1AUCUPk%2F9QN1JKA%3D%3D"}]}
Server: cloudflare
Transfer-Encoding: chunked
X-Powered-By: Express
alt-svc: h3=":443"; ma=86400
cf-cache-status: DYNAMIC
vary: accept-encoding
```

### After changes
Command:
```shell
http --all --follow --headers https://slack-signup.creativecommons.org/
```
Output:
```http
HTTP/1.1 301 Moved Permanently
CF-RAY: 9832f26c6cf20ea1-MXP
Connection: keep-alive
Content-Type: text/html
Date: Mon, 22 Sep 2025 15:48:31 GMT
Server: cloudflare
Transfer-Encoding: chunked
cf-cache-status: DYNAMIC
location: https://creativecommons.zulipchat.com/login/
strict-transport-security: max-age=15768000
x-content-type-options: nosniff
x-frame-options: deny
x-xss-protection: 1; mode=block

HTTP/1.1 200 OK
Cache-Control: max-age=0, no-cache, no-store, must-revalidate, private
Connection: keep-alive
Content-Encoding: gzip
Content-Language: en
Content-Type: text/html; charset=utf-8
Date: Mon, 22 Sep 2025 15:48:31 GMT
Expires: Mon, 22 Sep 2025 15:48:31 GMT
Server: nginx/1.24.0 (Ubuntu)
Set-Cookie: __Host-csrftoken=YgqS7p5dsWmC6fKekH17psFXaDWhlrHe; expires=Mon, 21 Sep 2026 15:48:31 GMT; HttpOnly; Max-Age=31449600; Path=/; SameSite=Lax; Secure
Strict-Transport-Security: max-age=15768000
Transfer-Encoding: chunked
Vary: Accept-Encoding, Cookie, Accept-Language
X-Content-Type-Options: nosniff
X-Frame-Options: DENY

```

<!--
## Screenshots
<!-- Add screenshots to show the problem and the solution; or comment out this section entirely. -->

## Checklist
<!-- DON'T remove this section or any of the lines. -->
<!-- Leave incomplete or inapplicable lines unchecked. -->
<!-- Replace the [ ] with [x] to check the boxes (there is no space between x and square brackets). -->
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- YOU MUST READ AND UNDERSTAND THE FOLLOWING ATTESTATION. -->
<!-- -->
<!-- Be aware that copying and pasting from discussion sites or generative AI isn't allowed under this DCO. -->

For the purposes of this DCO, "license" is equivalent to "license or public domain dedication," and "open source license" is equivalent to "open content license or public domain dedication."
<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
