### PR TITLE
Actually manage Apache2 MaxRequestWorkers

### DIFF
--- a/states/apache2/mpm_prefork.sls
+++ b/states/apache2/mpm_prefork.sls
@@ -4,14 +4,14 @@
 #                Memory    Memory
 #   Instance     listed      real  Workers
 #   ---------  --------  --------  -------
-#   t3.nano     512 MiB   439 MiB       16
-#   t3.micro   1024 MiB   945 MiB       32
-#   t3.small   2048 MiB  1932 MiB       80
-#   t3.medium  4096 MiB  3873 MiB      176
+#   t3.nano     512 MiB   439 MiB        8
+#   t3.micro   1024 MiB   945 MiB       29
+#   t3.small   2048 MiB  1932 MiB       70
+#   t3.medium  4096 MiB  3873 MiB      151
 #
 # To view real memory available, use the following command:
 #   sudo salt \* grains.item saltenv=${USER} mem_total
-{% set WORKERS = (((grains.mem_total - 256) / 320)|round * 16)|int -%}
+{% set WORKERS = ((grains.mem_total - 256) / 24)|round|int -%}
 
 # This should only match the first time Salt is run against the host
 {{ sls }} initial MaxRequestWorkers:


### PR DESCRIPTION
## Related issues
- Related to creativecommons/tech-support/issues/1388 (private repo)
- Related to creativecommons/tech-support/issues/1392 (private repo)
  - See this issue for additional context and documentation

## Description
Actually manage Apache2 `MaxRequestWorkers` (fix mistakes I made 5 years ago):
- improve existing stanza name
- add new stanza for invocations after the first
- improve explanation table

Change is currently only live on `index__prod`.

## Technical details
- [Hardware and Operating System Issues - Apache Performance Tuning - Apache HTTP Server Version 2.4](https://httpd.apache.org/docs/2.4/misc/perf-tuning.html#hardware)
- [salt.states.file.replace](https://docs.saltproject.io/en/3007/ref/states/all/salt.states.file.html#salt.states.file.replace)
- [re — Regular expression operations — Python 3.10 documentation](https://docs.python.org/3.10/library/re.html)
- #107 

## Tests
Verified against multiple hosts that it only makes the changes when value is wrong

<!--
## Screenshots
<!-- Add screenshots to show the problem and the solution; or comment out this section entirely. -->

## Checklist
<!-- DON'T remove this section or any of the lines. -->
<!-- Leave incomplete or inapplicable lines unchecked. -->
<!-- Replace the [ ] with [x] to check the boxes (there is no space between x and square brackets). -->
- [x] I have read and understood the Developer Certificate of Origin (DCO), below, which covers the contents of this pull request (PR).
- [x] My pull request doesn't include code or content generated with AI.
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated unit tests and/or test scripts for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- YOU MUST READ AND UNDERSTAND THE FOLLOWING ATTESTATION. -->
<!-- -->
<!-- Be aware that copying and pasting from discussion sites or generative AI isn't allowed under this DCO. -->

For the purposes of this DCO, "license" is equivalent to "license or public domain dedication," and "open source license" is equivalent to "open content license or public domain dedication."
<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
