### PR TITLE
Update Certbot

### DIFF
--- a/pillars/letsencrypt/init.sls
+++ b/pillars/letsencrypt/init.sls
@@ -12,13 +12,10 @@ letsencrypt:
     renew-with-new-domains: True
     server: https://acme-v02.api.letsencrypt.org/directory
     webroot-path: /var/www/html
-  {%- if grains.pythonversion[1] == 5 %}
-  {#- last supported version on Python 3.5 without a nag/warning #}
-  version: "1.6.0"
-  {%- elif grains.os == "Debian" and grains.osrelease|int == 11 %}
-  {#- Debian 11 (Bullseye): only supports up to 4.2.0 
+  {%- if grains.os == "Debian" and grains.osrelease|int == 11 %}
+  {#- Debian 11 (Bullseye): only supports up to 4.2.0
      refer to https://github.com/creativecommons/tech-support/issues/1361 #}
   version: "4.2.0"
   {%- else %}
-  version: "5.1.0"
+  version: "5.3.1"
   {%- endif %}


### PR DESCRIPTION
## Description
Update Certbot
- remove support for Python 3.5 (Debian stretch and older)
- update Python >3.9 (Debian Bookworm and newer) to Certbot 5.3.1
- All changes are live on all hosts
- Related to creativecommons/tech-support/issues/1417 (private repo)

## Technical details
- [Release Certbot 5.3.1 · certbot/certbot](https://github.com/certbot/certbot/releases/tag/v5.3.1)
- [Release Certbot 5.3.0 · certbot/certbot](https://github.com/certbot/certbot/releases/tag/v5.3.0)
- [Release Certbot 5.2.2 · certbot/certbot](https://github.com/certbot/certbot/releases/tag/v5.2.2)
- [Release Certbot 5.2.1 · certbot/certbot](https://github.com/certbot/certbot/releases/tag/v5.2.1)

## Tests
Verify installed `certbot` version on all minions (if present):
```shell
sudo salt \* cmd.run '[ -f /usr/local/bin/certbot ] && /usr/local/bin/certbot --version'
```

Display certifictes on all minions (if `certbot` is present):
```shell
sudo salt \* cmd.run '[ -f /usr/local/bin/certbot ] && /usr/local/bin/certbot certificates'
```

<!--
## Screenshots
<!-- Add screenshots to show the problem and the solution; or comment out this section entirely. -->

## Checklist
<!-- DON'T remove this section or any of the lines. -->
<!-- Leave incomplete or inapplicable lines unchecked. -->
<!-- Replace the [ ] with [x] to check the boxes (there is no space between x and square brackets). -->
- [x] I have read and understood the Developer Certificate of Origin (DCO), below, which covers the contents of this pull request (PR).
- [x] My pull request doesn't include code or content generated with AI (also see [Avoiding generative AI development tools — Creative Commons Open Source][no-ai]).
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated unit tests and/or test scripts for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[no-ai]: https://opensource.creativecommons.org/blog/entries/2025-12-01-avoiding-gen-ai-tools/
[best_practices]: https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- YOU MUST READ AND UNDERSTAND THE FOLLOWING ATTESTATION. -->
<!-- -->
<!-- Be aware that copying and pasting from discussion sites or generative AI isn't allowed under this DCO. -->

For the purposes of this DCO, "license" is equivalent to "license or public domain dedication," and "open source license" is equivalent to "open content license or public domain dedication."
<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
