### PR TITLE
Add legacy and default legal tool version redirects, support RDF/XML requests via accept header

### DIFF
--- a/states/apache2/files/index.conf
+++ b/states/apache2/files/index.conf
@@ -32,10 +32,15 @@
     Alias /ns           /var/www/git/cc-legal-tools-data/docs/rdf/ns.html
     # Ensure lowercase
     RewriteMap lowercase int:tolower
-    RewriteCond %{REQUEST_URI} ^/(licenses|publicdomain) [NC]
+    RewriteCond %{REQUEST_URI} ^/(licences?|licenses?|publicdomain) [NC]
     RewriteCond %{REQUEST_URI} [A-Z]
     RewriteRule ^(.*)$ ${lowercase:$1} [R=301,L]
+    # Legacy/compatibilty redirects
+    RewriteRule  /license(/|$)   /licenses/  [R=301,L]
+    RewriteRule  /licences(/|$)  /licenses/  [R=301,L]
+    RewriteRule  /licence(/|$)   /licenses/  [R=301,L]
     <Directory /var/www/git/cc-legal-tools-data/docs>
+        Options -Indexes
         # Disable .htaccess (for security and performance)
         AllowOverride None
         # Enable CORS (cross-origin resource sharing)
@@ -59,16 +64,12 @@
         # Deny access to PHP files (content should be only static files)
         RewriteRule .*\.php$ "-" [F,L]
     </Directory>
-    # Legacy/compatibilty redirects
-    RedirectPermanent   /license                /licenses
-    RedirectPermanent   /licences               /licenses
-    RedirectPermanent   /licence                /licenses
     # Redirect legacy public domain URLs
-    RedirectPermanent   /licenses/publicdomain/ /publicdomain/certification/1.0/us/deed.en
-    RedirectPermanent   /licenses/mark/1.0      /publicdomain/mark/1.0
+    RedirectMatch  301  /licenses/(publicdomain)  /$1/certification/1.0/us
+    RedirectPermanent   /licenses/mark/1.0        /publicdomain/mark/1.0
     # Licenses 1.0 has reverse ordered components
-    RedirectPermanent   /licenses/nc-nd/1.0             /licenses/nd-nc/1.0
-    RedirectPermanent   /licenses/by-nc-nd/1.0          /licenses/by-nd-nc/1.0
+    RedirectPermanent  /licenses/nc-nd/1.0     /licenses/nd-nc/1.0
+    RedirectPermanent  /licenses/by-nc-nd/1.0  /licenses/by-nd-nc/1.0
     # Licenses 2.1 only includes ports
     RedirectMatch  301  /licenses/([^/]+)/2.1/(lega.*)  /licenses/$1/2.0/$2
     RedirectMatch  301  /licenses/([^/]+)/2.1/(deed.*)  /licenses/$1/2.0/$2
@@ -83,14 +84,14 @@
     RedirectMatch  302  (/licenses/by-nc)/?$     $1/4.0/
     RedirectMatch  302  (/licenses/by)/?$        $1/4.0/
     # Default legal tool versions - retired
-    RedirectMatch  301  (/publicdomain/certification)/?$  $1/1.0/
+    RedirectMatch  301  (/publicdomain/certification)/?$  $1/1.0/us/
     RedirectMatch  301  (/licenses/sampling[+])/?$        $1/1.0/
     RedirectMatch  301  (/licenses/sampling)/?$           $1/1.0/
-    RedirectMatch  301  (/licenses/sa)/?$                 $1/2.0/
-    RedirectMatch  301  (/licenses/nd-nc)/?$              $1/2.0/
-    RedirectMatch  301  (/licenses/nc)/?$                 $1/2.0/
+    RedirectMatch  301  (/licenses/sa)/?$                 $1/1.0/
+    RedirectMatch  301  (/licenses/nd-nc)/?$              $1/1.0/
+    RedirectMatch  301  (/licenses/nc)/?$                 $1/1.0/
     RedirectMatch  301  (/licenses/nc-sampling[+])/?$     $1/1.0/
-    RedirectMatch  301  (/licenses/nc-sa)/?$              $1/2.0/
+    RedirectMatch  301  (/licenses/nc-sa)/?$              $1/1.0/
     RedirectMatch  301  (/licenses/devnations)/?$         $1/2.0/
 
     ###########################################################################
@@ -103,6 +104,7 @@
     # FAQ
     Alias /faq /var/www/git/faq/faq
     <Directory /var/www/git/faq/faq>
+        Options -Indexes
         # Disable .htaccess (for security and performance)
         AllowOverride None
         # Redirect .../index.php to .../
@@ -117,6 +119,7 @@
     # Platform Toolkit
     Alias /platform/toolkit /var/www/git/mp/docs
     <Directory /var/www/git/mp/docs>
+        Options -Indexes
         # Disable .htaccess (for security and performance)
         AllowOverride None
         # Redirect .../index.php to .../
@@ -145,14 +148,17 @@
     </Directory>
     <Directory {{ DOCROOT }}/backup>
         AllowOverride None
+        Options -Indexes
         Require all denied
     </Directory>
     <Directory {{ DOCROOT }}/wp/wp-admin/includes>
         AllowOverride None
+        Options -Indexes
         Require all denied
     </Directory>
     <Directory {{ DOCROOT }}/wp/wp-includes/theme-compat>
         AllowOverride None
+        Options -Indexes
         Require all denied
     </Directory>
     <Directory {{ DOCROOT }}/wp-content/uploads>
@@ -160,6 +166,7 @@
         <FilesMatch "[.]ph(?:p\d?|t|tml)$">
             Require all denied
         </FilesMatch>
+        Options -Indexes
     </Directory>
     <FilesMatch "^[.]?wp-config[.]php">
         Require all denied
@@ -241,6 +248,7 @@
     <Directory {{ DOCROOT }}/cache-uploads>
         AllowOverride None
         # Options default is FollowSymlinks
+        Options -Indexes
         Require local
     </Directory>
 

--- a/states/apache2/files/index.conf
+++ b/states/apache2/files/index.conf
@@ -22,7 +22,6 @@
     ###########################################################################
     # CC Legal Tools
     # Directory Aliases
-    Alias /status           /var/www/git/cc-legal-tools-data/docs/status
     Alias /rdf              /var/www/git/cc-legal-tools-data/docs/rdf
     Alias /publicdomain     /var/www/git/cc-legal-tools-data/docs/publicdomain
     Alias /licenses         /var/www/git/cc-legal-tools-data/docs/licenses
@@ -43,10 +42,15 @@
         Header set Access-Control-Allow-Origin "*"
         # Correct mimetype for .../rdf files
         RewriteRule /rdf$ - [T=application/rdf+xml]
+        # Serve RDF/XML when requested, even if URL is for index (deed), deed,
+        # or legalcode
+        RewriteCond %{HTTP_ACCEPT} application/rdf\+xml
+        RewriteCond %{REQUEST_URI} (/(licenses|publicdomain)/[^/]+/.*)(/.*)
+        RewriteRule "(.*)(/|/deed.*|/index.*|/legalcode.*)$" "%1/rdf" [R=303]
         # Language redirects
         Include /var/www/git/cc-legal-tools-data/config/language-redirects
         # Also serve HTML files without .html extension
-        RewriteCond %{REQUEST_FILENAME}.html -f
+        RewriteCond %{LA-F:REQUEST_FILENAME}.html -f
         RewriteRule !.*\.html$ %{REQUEST_FILENAME}.html [L]
         # Redirect .../index.php to .../
         RewriteCond %{REQUEST_FILENAME} "index\.php$" [NC]
@@ -56,31 +60,42 @@
         RewriteRule .*\.php$ "-" [F,L]
     </Directory>
     # Legacy/compatibilty redirects
-    RedirectPermanent   /licenses/work-html-popup       /choose
-    RedirectPermanent   /licences                       /licenses
+    RedirectPermanent   /license                /licenses
+    RedirectPermanent   /licences               /licenses
+    RedirectPermanent   /licence                /licenses
     # Redirect legacy public domain URLs
-    RedirectPermanent   /licenses/publicdomain/         /publicdomain/
-    RedirectPermanent   /licenses/mark/1.0              /publicdomain/mark/1.0
+    RedirectPermanent   /licenses/publicdomain/ /publicdomain/certification/1.0/us/deed.en
+    RedirectPermanent   /licenses/mark/1.0      /publicdomain/mark/1.0
     # Licenses 1.0 has reverse ordered components
     RedirectPermanent   /licenses/nc-nd/1.0             /licenses/nd-nc/1.0
     RedirectPermanent   /licenses/by-nc-nd/1.0          /licenses/by-nd-nc/1.0
     # Licenses 2.1 only includes ports
     RedirectMatch  301  /licenses/([^/]+)/2.1/(lega.*)  /licenses/$1/2.0/$2
     RedirectMatch  301  /licenses/([^/]+)/2.1/(deed.*)  /licenses/$1/2.0/$2
+    # Default legal tool versions - current
+    RedirectMatch  302  (/publicdomain/zero)/?$  $1/1.0/
+    RedirectMatch  302  (/publicdomain/mark)/?$  $1/1.0/
+    RedirectMatch  302  (/licenses/by-sa)/?$     $1/4.0/
+    RedirectMatch  302  (/licenses)/by-nd-nc/?$  $1/by-nc-nd/4.0/
+    RedirectMatch  302  (/licenses/by-nd)/?$     $1/4.0/
+    RedirectMatch  302  (/licenses/by-nc-sa)/?$  $1/4.0/
+    RedirectMatch  302  (/licenses/by-nc-nd)/?$  $1/4.0/
+    RedirectMatch  302  (/licenses/by-nc)/?$     $1/4.0/
+    RedirectMatch  302  (/licenses/by)/?$        $1/4.0/
+    # Default legal tool versions - retired
+    RedirectMatch  301  (/publicdomain/certification)/?$  $1/1.0/
+    RedirectMatch  301  (/licenses/sampling[+])/?$        $1/1.0/
+    RedirectMatch  301  (/licenses/sampling)/?$           $1/1.0/
+    RedirectMatch  301  (/licenses/sa)/?$                 $1/2.0/
+    RedirectMatch  301  (/licenses/nd-nc)/?$              $1/2.0/
+    RedirectMatch  301  (/licenses/nc)/?$                 $1/2.0/
+    RedirectMatch  301  (/licenses/nc-sampling[+])/?$     $1/1.0/
+    RedirectMatch  301  (/licenses/nc-sa)/?$              $1/2.0/
+    RedirectMatch  301  (/licenses/devnations)/?$         $1/2.0/
 
     ###########################################################################
     # Chooser
-#    Alias /choose /var/www/git/chooser/docs
-#    <Directory /var/www/git/chooser/docs>
-#        # Disable .htaccess (for security and performance)
-#        AllowOverride None
-#        # Redirect .../index.php to .../
-#        RewriteCond %{REQUEST_FILENAME} "index\.php$" [NC]
-#        RewriteCond %{REQUEST_FILENAME} !-f
-#        RewriteRule (.*/)index\.php$ $1 [L,NC,R=301]
-#        # Deny access to PHP files (content should be only static files)
-#        RewriteRule .*\.php "-" [F,L]
-#    </Directory>
+    RedirectPermanent   /licenses/work-html-popup       /choose
     RedirectTemp  /choose/mark/  https://wiki.creativecommons.org/wiki/PDM_FAQ
     RedirectTemp  /choose/mark   https://wiki.creativecommons.org/wiki/PDM_FAQ
 


### PR DESCRIPTION
<!-- ⚠️ Pull requests (PRs) that don't follow this template will be discarded. -->
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please open one before creating this pull request. -->
<!-- Replace [issue number] with the issue number (don't leave the square brackets)--likewise for [issue author]. -->
- Fixes creativecommons/cc-legal-tools-app/issues/571
- Fixes creativecommons/creativecommons.org/issues/1431
- Fixes #253

## Description
Add redirects to better support:
- Legacy/misspelling URIs
- Legal tool URIs without a version
- RDF/XML requests via Accept header
- (currently deployed to staging)

## Technical details
- [mod_rewrite - Apache HTTP Server Version 2.4](https://httpd.apache.org/docs/current/mod/mod_rewrite.html)
- [Accept header - HTTP | MDN](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Accept)
- [303 See Other - HTTP | MDN](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Status/303)

## Tests
1. Tested in dev:
   - creativecommons/index-dev-env/pull/114
   - creativecommons/index-dev-env/pull/115
2. Tested in staging
   - Used script in `creativecommons/index-dev-env`: [`test_legal_tool_urls.sh`](https://github.com/creativecommons/index-dev-env/blob/261bdfe81c5b97487827f2a9b5c3736a97d95c85/test_legal_tool_urls.sh)
   - (requires credentials in `.netrc`)

<!--
## Screenshots
<!-- Add screenshots to show the problem and the solution; or comment out this section entirely. -->

## Checklist
<!-- DON'T remove this section or any of the lines. -->
<!-- Leave incomplete or inapplicable lines unchecked. -->
<!-- Replace the [ ] with [x] to check the boxes (there is no space between x and square brackets). -->
- [x] I have read and understood the Developer Certificate of Origin (DCO), below, which covers the contents of this pull request (PR).
- [x] My pull request doesn't include code or content generated with AI (also see [Avoiding generative AI development tools — Creative Commons Open Source][no-ai]).
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added or updated unit tests and/or test scripts for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[no-ai]: https://opensource.creativecommons.org/blog/entries/2025-12-01-avoiding-gen-ai-tools/
[best_practices]: https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- YOU MUST READ AND UNDERSTAND THE FOLLOWING ATTESTATION. -->
<!-- -->
<!-- Be aware that copying and pasting from discussion sites or generative AI isn't allowed under this DCO. -->

For the purposes of this DCO, "license" is equivalent to "license or public domain dedication," and "open source license" is equivalent to "open content license or public domain dedication."
<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
