### PR TITLE
Fully manage mpm_prefork.conf (and add ServerLimit)

### DIFF
--- a/states/apache2/files/mpm_prefork.conf
+++ b/states/apache2/files/mpm_prefork.conf
@@ -1,0 +1,21 @@
+# Managed by SaltStack
+
+# prefork MPM
+# StartServers: number of server processes to start
+# MinSpareServers: minimum number of server processes which are kept spare
+# MaxSpareServers: maximum number of server processes which are kept spare
+# MaxRequestWorkers: maximum number of server processes allowed to start
+# ServerLimit: Upper limit on configurable number of processes
+# MaxConnectionsPerChild: maximum number of requests a server process serves
+
+<IfModule mpm_prefork_module>
+    StartServers            5
+    MinSpareServers         5
+    MaxSpareServers         10
+    MaxRequestWorkers       {{ WORKERS }}
+    ServerLimit             {{ WORKERS }}
+
+    MaxConnectionsPerChild  0
+</IfModule>
+
+# vim: syntax=apache ts=4 sw=4 sts=4 sr et

--- a/states/apache2/mpm_prefork.sls
+++ b/states/apache2/mpm_prefork.sls
@@ -1,48 +1,40 @@
 # https://httpd.apache.org/docs/2.4/misc/perf-tuning.html#hardware
 #
 # The WORKERS formula, below, results in the following worker configurations:
-#                Memory    Memory
-#   Instance     listed      real  Workers
-#   ---------  --------  --------  -------
-#   t3.nano     512 MiB   439 MiB        8
-#   t3.micro   1024 MiB   945 MiB       29
-#   t3.small   2048 MiB  1932 MiB       70
-#   t3.medium  4096 MiB  3873 MiB      151
+#                 Memory    Memory
+#   Instance      listed      real  Workers
+#   ---------   --------  --------  -------
+#   t3.nano      512 MiB   439 MiB        8
+#   t3.micro    1024 MiB   945 MiB       29
+#   t3.small    2048 MiB  1932 MiB       70
+#   t3.medium   4096 MiB  3873 MiB      151
+#   r8a.medium  8192 MiB  7780 MiB      314
 #
 # To view real memory available, use the following command:
 #   sudo salt \* grains.item saltenv=${USER} mem_total
 {% set WORKERS = ((grains.mem_total - 256) / 24)|round|int -%}
 
-# This should only match the first time Salt is run against the host
-{{ sls }} initial MaxRequestWorkers:
-  file.replace:
-    - name: /etc/apache2/mods-available/mpm_prefork.conf
-    - pattern: ^\s*MaxRequestWorkers\s+150\s*$
-    - repl: >-
-        \t# Managed by SaltStack: {{ sls }}\n
-        \t#MaxRequestWorkers\t  150\n
-        \tMaxRequestWorkers\t  {{ WORKERS }}\n
-    - flags:
-      - IGNORECASE
-      - MULTILINE
+
+{{ sls }} backup original mpm_prefork.conf:
+  file.copy:
+    - name: /etc/apache2/mods-available/mpm_prefork.conf.orig
+    - source: /etc/apache2/mods-available/mpm_prefork.conf
+    - force: False
+    - preserve: True
     - require:
       - pkg: apache2 installed packages
-    - watch_in:
-      - service: apache2 service
 
-{{ sls }} manage MaxRequestWorkers:
-  file.replace:
+
+{{ sls }} manage mpm_prefork.conf:
+  file.managed:
     - name: /etc/apache2/mods-available/mpm_prefork.conf
-    # The following pattern is a little weird. It uses a negative lookahead
-    # assertion to prevent churn. Because negative lookahead assertion don't
-    # consume any of string, it is followed by a one or more decimal digit
-    # match
-    - pattern: ^\s*MaxRequestWorkers\s+(?!{{ WORKERS }})\d+
-    - repl: \tMaxRequestWorkers\t  {{ WORKERS }}
-    - flags:
-      - IGNORECASE
-      - MULTILINE
+    - source: salt://apache2/files/mpm_prefork.conf
+    - mode: '0444'
+    - template: jinja
+    - defaults:
+        WORKERS: {{ WORKERS }}
     - require:
+      - file: {{ sls }} backup original mpm_prefork.conf 
       - pkg: apache2 installed packages
     - watch_in:
       - service: apache2 service


### PR DESCRIPTION
<!-- ⚠️ Pull requests (PRs) that don't follow this template will be discarded. -->
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, please open one before creating this pull request. -->
<!-- Replace [issue number] with the issue number (don't leave the square brackets)--likewise for [issue author]. -->
- Fixes #337

## Description
Fully manage `mpm_prefork.conf` (and add `ServerLimit`)
- Changes are live on all hosts

<!--
## Technical details
<!-- Add any other information or technical details about the implementation; or delete this section entirely. -->


## Tests
On `index__prod__us-east-2`:
- Command:
    ```shell
    status apache2 | grep WARNING
    ```
- Output (empty):
    ```
    ```

<!--
## Screenshots
<!-- Add screenshots to show the problem and the solution; or comment out this section entirely. -->

## Checklist
<!-- DON'T remove this section or any of the lines. -->
<!-- Leave incomplete or inapplicable lines unchecked. -->
<!-- Replace the [ ] with [x] to check the boxes (there is no space between x and square brackets). -->
- [x] I have read and understood the Developer Certificate of Origin (DCO), below, which covers the contents of this pull request (PR).
- [x] My pull request doesn't include code or content generated with AI (also see [Avoiding generative AI development tools — Creative Commons Open Source][no-ai]).
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated unit tests and/or test scripts for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[no-ai]: https://opensource.creativecommons.org/blog/entries/2025-12-01-avoiding-gen-ai-tools/
[best_practices]: https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- YOU MUST READ AND UNDERSTAND THE FOLLOWING ATTESTATION. -->
<!-- -->
<!-- Be aware that copying and pasting from discussion sites or generative AI isn't allowed under this DCO. -->

For the purposes of this DCO, "license" is equivalent to "license or public domain dedication," and "open source license" is equivalent to "open content license or public domain dedication."
<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
