### PR TITLE
Update Certbot (Let's Encrypt) to 5.6.0 (from 5.3.1)

### DIFF
--- a/pillars/5_HST__POD/redirects__core.sls
+++ b/pillars/5_HST__POD/redirects__core.sls
@@ -36,81 +36,81 @@ nginx:
   redirect_default: redirects.creativecommons.org
   redirects:
     # redirects.creativecommons.org
-    - crt: redirects.creativecommons.org-0001
+    - crt: redirects.creativecommons.org
       src: au-beta.creativecommons.org
       dst: au-beta.creativecommons.net
-    - crt: redirects.creativecommons.org-0001
+    - crt: redirects.creativecommons.org
       src: br.creativecommons.org
       dst: br.creativecommons.net
-    - crt: redirects.creativecommons.org-0001
+    - crt: redirects.creativecommons.org
       src: ca-beta.creativecommons.org
       dst: ca-beta.creativecommons.net
-    - crt: redirects.creativecommons.org-0001
+    - crt: redirects.creativecommons.org
       src: ca.creativecommons.org
       dst: ca.creativecommons.net
-    - crt: redirects.creativecommons.org-0001
+    - crt: redirects.creativecommons.org
       src: ccsearch.creativecommons.org
       dst: search.creativecommons.org
-    - crt: redirects.creativecommons.org-0001
+    - crt: redirects.creativecommons.org
       src: co.creativecommons.org
       dst: co.creativecommons.net
-    - crt: redirects.creativecommons.org-0001
+    - crt: redirects.creativecommons.org
       src: code.creativecommons.org
       dst: opensource.creativecommons.org
-    - crt: redirects.creativecommons.org-0001
+    - crt: redirects.creativecommons.org
       src: chapters.creativecommons.org
       dst: creativecommons.net
-    - crt: redirects.creativecommons.org-0001
+    - crt: redirects.creativecommons.org
       src: de.creativecommons.org
       dst: de.creativecommons.net
-    - crt: redirects.creativecommons.org-0001
+    - crt: redirects.creativecommons.org
       src: i.creativecommons.org
       dst: licensebuttons.net
-    - crt: redirects.creativecommons.org-0001
+    - crt: redirects.creativecommons.org
       src: it.creativecommons.org
       dst: creativecommons.it
-    - crt: redirects.creativecommons.org-0001
+    - crt: redirects.creativecommons.org
       src: jp.creativecommons.org
       dst: creativecommons.jp
-    - crt: redirects.creativecommons.org-0001
+    - crt: redirects.creativecommons.org
       src: ke-beta.creativecommons.org
       dst: ke-beta.creativecommons.net
-    - crt: redirects.creativecommons.org-0001
+    - crt: redirects.creativecommons.org
       src: newsearch.creativecommons.org
       dst: search.creativecommons.org
-    - crt: redirects.creativecommons.org-0001
+    - crt: redirects.creativecommons.org
       src: mx.creativecommons.org
       dst: mx.creativecommons.net
-    - crt: redirects.creativecommons.org-0001
+    - crt: redirects.creativecommons.org
       src: mx-beta.creativecommons.org
       dst: mx.creativecommons.net
-    - crt: redirects.creativecommons.org-0001
+    - crt: redirects.creativecommons.org
       src: nl-beta.creativecommons.org
       dst: nl-beta.creativecommons.net
-    - crt: redirects.creativecommons.org-0001
+    - crt: redirects.creativecommons.org
       src: nl.creativecommons.org
       dst: creativecommons.nl
-    - crt: redirects.creativecommons.org-0001
+    - crt: redirects.creativecommons.org
       src: oldsearch.creativecommons.org
       dst: search.creativecommons.org
-    - crt: redirects.creativecommons.org-0001
+    - crt: redirects.creativecommons.org
       src: pl.creativecommons.org
       dst: creativecommons.pl
-    - crt: redirects.creativecommons.org-0001
+    - crt: redirects.creativecommons.org
       src: slack-signup.creativecommons.org
       dst: creativecommons.zulipchat.com/login/
       ignore_request_uri: true
-    - crt: redirects.creativecommons.org-0001
+    - crt: redirects.creativecommons.org
       src: support.creativecommons.org
       dst: classy.org/give/313412/#!/donation/checkout
       ignore_request_uri: true
-    - crt: redirects.creativecommons.org-0001
+    - crt: redirects.creativecommons.org
       src: sotc.creativecommons.org
       dst: stateof.creativecommons.org
-    - crt: redirects.creativecommons.org-0001
+    - crt: redirects.creativecommons.org
       src: sv.creativecommons.org
       dst: sv.creativecommons.net
-    - crt: redirects.creativecommons.org-0001
+    - crt: redirects.creativecommons.org
       src: za.creativecommons.org
       dst: za.creativecommons.net
     #    api.creativecommons.engineering has custom configuration, see state

--- a/pillars/letsencrypt/init.sls
+++ b/pillars/letsencrypt/init.sls
@@ -17,5 +17,5 @@ letsencrypt:
      refer to https://github.com/creativecommons/tech-support/issues/1361 #}
   version: "4.2.0"
   {%- else %}
-  version: "5.3.1"
+  version: "5.6.0"
   {%- endif %}

--- a/states/nginx/files/redirects_default
+++ b/states/nginx/files/redirects_default
@@ -21,8 +21,8 @@ server {
     listen 443 ssl http2;
     listen [::]:443 ssl http2;
     access_log off;
-    ssl_certificate /etc/letsencrypt/live/redirects.creativecommons.org-0001/fullchain.pem;
-    ssl_certificate_key /etc/letsencrypt/live/redirects.creativecommons.org-0001/privkey.pem;
+    ssl_certificate /etc/letsencrypt/live/redirects.creativecommons.org/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/redirects.creativecommons.org/privkey.pem;
     # Redirect everything to creativecommons.org
     return 301 https://creativecommons.org$request_uri;
 }


### PR DESCRIPTION
<!-- ⚠️ Pull requests (PRs) that don't follow this template will be discarded. -->
## Description
Update Certbot (Let's Encrypt) to `5.6.0` (from ~~`5.3.1`~~)
- Change primary certificate on `redirects__core__us-east-2`
  - (clean-up #335)
- Changes are live on all hosts

## Technical details
- [Release Certbot 5.4.0 · certbot/certbot](https://github.com/certbot/certbot/releases/tag/v5.4.0)
- [Release Certbot 5.5.0 · certbot/certbot](https://github.com/certbot/certbot/releases/tag/v5.5.0)
- [Release Certbot 5.6.0 · certbot/certbot](https://github.com/certbot/certbot/releases/tag/v5.6.0)

## Tests
1. Verify installed `certbot` version on all minions (if present):
    ```shell
    sudo salt \* cmd.run '[ -f /usr/local/bin/certbot ] && /usr/local/bin/certbot --version || true'
    ```
2. Display certifictes on all minions (if `certbot` is present):
    ```shell
    sudo salt \* cmd.run '[ -f /usr/local/bin/certbot ] && /usr/local/bin/certbot certificates || true'
    ```
3. Test certbot on all minions (if present):
    ```shell
    sudo salt \* cmd.run '[ -f /usr/local/bin/certbot ] && /usr/local/bin/certbot renew --dry-run || true'
    ```

<!--
## Screenshots
<!-- Add screenshots to show the problem and the solution; or comment out this section entirely. -->

## Checklist
<!-- DON'T remove this section or any of the lines. -->
<!-- Leave incomplete or inapplicable lines unchecked. -->
<!-- Replace the [ ] with [x] to check the boxes (there is no space between x and square brackets). -->
- [x] I have read and understood the Developer Certificate of Origin (DCO), below, which covers the contents of this pull request (PR).
- [x] My pull request doesn't include code or content generated with AI (also see [Avoiding generative AI development tools — Creative Commons Open Source][no-ai]).
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated unit tests and/or test scripts for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[no-ai]: https://opensource.creativecommons.org/blog/entries/2025-12-01-avoiding-gen-ai-tools/
[best_practices]: https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- YOU MUST READ AND UNDERSTAND THE FOLLOWING ATTESTATION. -->
<!-- -->
<!-- Be aware that copying and pasting from discussion sites or generative AI isn't allowed under this DCO. -->

For the purposes of this DCO, "license" is equivalent to "license or public domain dedication," and "open source license" is equivalent to "open content license or public domain dedication."
<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
