### PR TITLE
Add plausible proxy

### DIFF
--- a/states/apache2/files/index.conf
+++ b/states/apache2/files/index.conf
@@ -11,13 +11,27 @@
     SSLCertificateFile {{ LE_CERT_PATH }}/fullchain.pem
     SSLCertificateKeyFile {{ LE_CERT_PATH }}/privkey.pem
 
-    RewriteEngine On
-
     # Ensure plaintext files are served using UTF-8
     AddCharset utf-8 .txt
 
     # Log Rewrite actions (use trace1 - trace8 for detailed logging)
     LogLevel rewrite:warn
+
+    ProxyPreserveHost Off
+    ProxyRequests Off
+    RewriteEngine On
+    SSLProxyEngine On
+
+    ###########################################################################
+    # Privacy-friendly analytics by Plausible
+    <Location /p/script.js>
+        ProxyPass https://plausible.io/js/pa-WRMaH3QHcCo_0RYbTsBgi.js
+        ProxyPassReverse https://plausible.io/js/pa-WRMaH3QHcCo_0RYbTsBgi.js
+    </Location>
+    <Location /p/api/event>
+        ProxyPass https://plausible.io/api/event
+        ProxyPassReverse https://plausible.io/api/event
+    </Location>
 
     ###########################################################################
     # CC Legal Tools
@@ -192,6 +206,7 @@
     RewriteCond %{REQUEST_URI} !^/rdf(/|$)
     RewriteCond %{REQUEST_URI} !^/publicdomain(/|$)
     RewriteCond %{REQUEST_URI} !^/platform/toolkit(/|$)
+    RewriteCond %{REQUEST_URI} !^/p/
     RewriteCond %{REQUEST_URI} !^/licen[cs]es(/|$)
     RewriteCond %{REQUEST_URI} !^/faq(/|$)
     RewriteCond %{REQUEST_URI} !^/choose/mark(/|$)
@@ -214,6 +229,7 @@
     RewriteCond %{REQUEST_URI} !^/rdf(/|$)
     RewriteCond %{REQUEST_URI} !^/publicdomain(/|$)
     RewriteCond %{REQUEST_URI} !^/platform/toolkit(/|$)
+    RewriteCond %{REQUEST_URI} !^/p/
     RewriteCond %{REQUEST_URI} !^/licen[cs]es(/|$)
     RewriteCond %{REQUEST_URI} !^/faq(/|$)
     RewriteCond %{REQUEST_URI} !^/choose/mark(/|$)

--- a/states/wordpress/index.sls
+++ b/states/wordpress/index.sls
@@ -1,3 +1,4 @@
+{% import "apache2/jinja2.sls" as a2 with context -%}
 {% set POD = pillar.pod -%}
 {% set DOCROOT = pillar.wordpress.docroot -%}
 {% set GIT = "/var/www/git" -%}
@@ -6,6 +7,10 @@
 {% set THEMES = "{}/themes".format(WP_CONTENT) -%}
 {% set STAGE_USER = salt.pillar.get("apache2:stage_username", false) -%}
 {% set STAGE_PASS = salt.pillar.get("apache2:stage_password", false) -%}
+
+
+{{ a2.enable_mods(sls, ["proxy"]) }}
+{{ a2.enable_mods(sls, ["proxy_http"]) }}
 
 
 {% if POD.startswith("stage") -%}


### PR DESCRIPTION
<!-- ⚠️ Pull requests (PRs) that don't follow this template will be discarded. -->
## Related
- creativecommons/tech-support/issues/1421 (private repository)

## Description
Add Plausible proxy
- (only the `creativecommons.org` domain is allowed in analytics configuration--`stage.creativecommons.org` stats are dropped)
- Based on testing in development:
  - creativecommons/index-dev-env/pull/117
- Changes were tested in staging first
- All changes are live in both product and staging

## Technical details
- [Proxying Plausible through Apache HTTP Server | Plausible docs](https://plausible.io/docs/proxy/guides/apache)

## Tests
<details>
<summary>Simple command line tests (click to expand)</summary>

### URL tests
Command from [creativecommons/index-dev-env/](https://github.com/creativecommons/index-dev-env/):
```shell
./test_legal_tool_urls.sh 'https://creativecommons.org/'
```
Ouptut:
(all as expected)

### Script on stage
Command:
```shell
http --all --follow --headers 'https://[REDACTED]:[REDACTED]@stage.creativecommons.org/p/script.js'
```
Output
```http
HTTP/1.1 200 OK
Accept-CH: Sec-CH-UA-Platform, Sec-CH-UA
Access-Control-Allow-Origin: *
CDN-Cache: EXPIRED
CDN-CachedAt: 06/09/2026 13:40:07
CDN-EdgeStorageId: 1233
CDN-ProxyVer: 1.55
CDN-PullZone: 682664
CDN-RequestCountryCode: US
CDN-RequestId: 0e0b64268a51285ddd8137b226211534
CDN-RequestPullCode: 200
CDN-RequestPullSuccess: True
CDN-RequestTime: 0
CDN-Status: 200
CF-RAY: a0908bd829b80e5a-MXP
Cache-Control: public, max-age=60, no-transform
Connection: keep-alive
Content-Type: application/javascript
Cross-Origin-Resource-Policy: cross-origin
Date: Tue, 09 Jun 2026 13:40:07 GMT
Server: cloudflare
Transfer-Encoding: chunked
Vary: Accept-Encoding
Via: 1.1 Caddy
X-Content-Type-Options: nosniff
application: 127.0.0.1
cdn-tag: tracker_script::pa-WRMaH3QHcCo_0RYbTsBgi
cf-cache-status: EXPIRED
last-modified: Tue, 09 Jun 2026 13:40:07 GMT
permissions-policy: interest-cohort=()
```

### Event on stage
Command:
```shell
http --all --follow --headers POST 'https://[REDACTED]:[REDACTED]@stage.creativecommons.org/p/api/event'
```
Output
```http
HTTP/1.1 400 Bad Request
Accept-CH: Sec-CH-UA-Platform, Sec-CH-UA
Access-Control-Allow-Credentials: true
Access-Control-Allow-Origin: *
CDN-CachedAt: 06/09/2026 13:40:42
CDN-EdgeStorageId: 1347
CDN-ProxyVer: 1.55
CDN-PullZone: 682664
CDN-RequestCountryCode: US
CDN-RequestId: 634eddb5a789f557e7dd83da010e4ee9
CDN-RequestPullCode: 400
CDN-RequestPullSuccess: True
CDN-RequestTime: 0
CF-RAY: a0908cb14cbc83b4-MXP
Cache-Control: max-age=0, private, must-revalidate
Connection: keep-alive
Content-Length: 94
Content-Type: application/json; charset=utf-8
Date: Tue, 09 Jun 2026 13:40:42 GMT
Server: cloudflare
Via: 1.1 Caddy
X-Request-ID: GLdtYUaKPkIuLwkFo6CF
application: 127.0.0.1
cf-cache-status: DYNAMIC
permissions-policy: interest-cohort=()
```
(400 Bad Request expected due to lack of valid payload)

### Script on prod
Command:
```shell
http --all --follow --headers 'https://creativecommons.org/p/script.js'
```
Output
```http
HTTP/1.1 200 OK
Accept-CH: Sec-CH-UA-Platform, Sec-CH-UA
Access-Control-Allow-Origin: *
CDN-Cache: EXPIRED
CDN-CachedAt: 06/09/2026 13:41:46
CDN-EdgeStorageId: 1430
CDN-ProxyVer: 1.55
CDN-PullZone: 682664
CDN-RequestCountryCode: US
CDN-RequestId: 5f4141a6dd5d7a986fa825f23815664c
CDN-RequestPullCode: 200
CDN-RequestPullSuccess: True
CDN-RequestTime: 0
CDN-Status: 200
CF-RAY: a0908e439e7c59dd-MXP
Cache-Control: public, max-age=60, no-transform
Connection: keep-alive
Content-Type: application/javascript
Cross-Origin-Resource-Policy: cross-origin
Date: Tue, 09 Jun 2026 13:41:46 GMT
Server: cloudflare
Transfer-Encoding: chunked
Vary: Accept-Encoding
Via: 1.1 Caddy
X-Content-Type-Options: nosniff
application: 127.0.0.1
cdn-tag: tracker_script::pa-WRMaH3QHcCo_0RYbTsBgi
cf-cache-status: MISS
last-modified: Tue, 09 Jun 2026 13:41:46 GMT
permissions-policy: interest-cohort=()
```

### Event on prod
Command:
```shell
http --all --follow --headers POST 'https://creativecommons.org/p/api/event'
```
Output
```http
HTTP/1.1 400 Bad Request
Accept-CH: Sec-CH-UA-Platform, Sec-CH-UA
Access-Control-Allow-Credentials: true
Access-Control-Allow-Origin: *
CDN-CachedAt: 06/09/2026 13:42:33
CDN-EdgeStorageId: 1348
CDN-ProxyVer: 1.55
CDN-PullZone: 682664
CDN-RequestCountryCode: US
CDN-RequestId: 10b211f3b2a3e8a054fa73edc7a13c02
CDN-RequestPullCode: 400
CDN-RequestPullSuccess: True
CDN-RequestTime: 0
CF-RAY: a0908f68fa5eee8e-MXP
Cache-Control: max-age=0, private, must-revalidate
Connection: keep-alive
Content-Length: 94
Content-Type: application/json; charset=utf-8
Date: Tue, 09 Jun 2026 13:42:33 GMT
Server: cloudflare
Via: 1.1 Caddy
X-Request-ID: GLdtezJ0zYMtsj4F-omC
application: 127.0.0.1
cf-cache-status: DYNAMIC
permissions-policy: interest-cohort=()
```
(400 Bad Request expected due to lack of valid payload)

</details>

<!--
## Screenshots
<!-- Add screenshots to show the problem and the solution; or comment out this section entirely. -->

## Checklist
<!-- DON'T remove this section or any of the lines. -->
<!-- Leave incomplete or inapplicable lines unchecked. -->
<!-- Replace the [ ] with [x] to check the boxes (there is no space between x and square brackets). -->
- [x] I have read and understood the Developer Certificate of Origin (DCO), below, which covers the contents of this pull request (PR).
- [x] My pull request doesn't include code or content generated with AI (also see [Avoiding generative AI development tools — Creative Commons Open Source][no-ai]).
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated unit tests and/or test scripts for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[no-ai]: https://opensource.creativecommons.org/blog/entries/2025-12-01-avoiding-gen-ai-tools/
[best_practices]: https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- YOU MUST READ AND UNDERSTAND THE FOLLOWING ATTESTATION. -->
<!-- -->
<!-- Be aware that copying and pasting from discussion sites or generative AI isn't allowed under this DCO. -->

For the purposes of this DCO, "license" is equivalent to "license or public domain dedication," and "open source license" is equivalent to "open content license or public domain dedication."
<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
