### PR TITLE
Reboot on OOM (OOM-killer is not invoked)

### DIFF
--- a/states/common/init.sls
+++ b/states/common/init.sls
@@ -1,4 +1,5 @@
 include:
+  - .oom_reboot
   - .virtual
   - amazon.cloudwatch_agent
 

--- a/states/common/oom_reboot.sls
+++ b/states/common/oom_reboot.sls
@@ -8,7 +8,7 @@
 {{ sls }} kernel.panic:
   sysctl.present:
     - name: kernel.panic
-    - value: 15
+    - value: 10
 
 
 # https://sysctl-explorer.net/vm/panic_on_oom/
@@ -23,3 +23,15 @@
     - value: 1
     - require:
       - sysctl: {{ sls }} kernel.panic
+
+
+# https://sysctl-explorer.net/vm/oom_kill_allocating_task/
+# > If this is set to non-zero, the OOM killer simply kills the task that
+# > triggered the out-of-memory condition. This avoids the expensive tasklist
+# > scan.
+{{ sls }} vm.oom_kill_allocating_task:
+  sysctl.present:
+    - name: vm.oom_kill_allocating_task
+    - value: 1
+    - require:
+      - sysctl: {{ sls }} vm.panic_on_oom

--- a/states/common/oom_reboot.sls
+++ b/states/common/oom_reboot.sls
@@ -1,0 +1,25 @@
+# Informed by:
+#   How-To: Reboot on OOM - Debuntu
+#   https://www.debuntu.org/how-to-reboot-on-oom/
+
+
+# https://sysctl-explorer.net/kernel/panic/
+# > number of seconds the kernel waits before rebooting on a panic
+{{ sls }} kernel.panic:
+  sysctl.present:
+    - name: kernel.panic
+    - value: 15
+
+
+# https://sysctl-explorer.net/vm/panic_on_oom/
+# > If this is set to 1, the kernel panics when out-of-memory happens. However,
+# > if a process limits using nodes by mempolicy/cpusets, and those nodes become
+# > memory exhaustion status, one process may be killed by oom-killer. No panic
+# > occurs in this case. Because other nodes’ memory may be free. This means
+# > system total status may be not fatal yet.
+{{ sls }} vm.panic_on_oom:
+  sysctl.present:
+    - name: vm.panic_on_oom
+    - value: 1
+    - require:
+      - sysctl: {{ sls }} kernel.panic


### PR DESCRIPTION
<!-- ⚠️ Pull requests (PRs) that don't follow this template will be discarded. -->
## Description
Reboot on out of memory (OOM)
- OOM-killer is not invoked (panic is not logged, only boot messages give indication)
- Changes are live on all hosts (as of `Mon 15 Jun 2026 09:01:40 AM UTC`)

## Technical details
- [How-To: Reboot on OOM - Debuntu](https://www.debuntu.org/how-to-reboot-on-oom/)
- [panic | sysctl-explorer.net](https://sysctl-explorer.net/kernel/panic/)
- [panic_on_oom | sysctl-explorer.net](https://sysctl-explorer.net/vm/panic_on_oom/)
- [oom_kill_allocating_task | sysctl-explorer.net](https://sysctl-explorer.net/vm/oom_kill_allocating_task/)
- [salt.states.sysctl](https://docs.saltproject.io/en/3006/ref/states/all/salt.states.sysctl.html)

## Tests
1. On `index__stage__us-east-2`
2. Install  `stress-ng`
    ```shell
    sudo apt-get install stress-ng
    ```
3. Trigger out of memory (OOM)
    ```shell
    stess-ng --bigheap 10
    ```
    - manpage expert for `--bigheap`:
      > start N workers that grow their heaps by  reallocating  memory.  If
      > the out of memory killer (OOM) on Linux kills the worker or the al‐
      > location fails then the allocating process starts all  over  again.
      > Note  that the OOM adjustment for the worker is set so that the OOM
      > killer will treat these workers as the first candidate processes to
      > kill.
4. Observe host become unresponsive and reboot
5. Uninstall `stress-ng`
    ```shell
    sudo apt-get remove stress-ng
    ```
    ```shell
    sudo apt autoremove
    ```


<!--
## Screenshots
<!-- Add screenshots to show the problem and the solution; or comment out this section entirely. -->

## Checklist
<!-- DON'T remove this section or any of the lines. -->
<!-- Leave incomplete or inapplicable lines unchecked. -->
<!-- Replace the [ ] with [x] to check the boxes (there is no space between x and square brackets). -->
- [x] I have read and understood the Developer Certificate of Origin (DCO), below, which covers the contents of this pull request (PR).
- [x] My pull request doesn't include code or content generated with AI (also see [Avoiding generative AI development tools — Creative Commons Open Source][no-ai]).
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated unit tests and/or test scripts for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[no-ai]: https://opensource.creativecommons.org/blog/entries/2025-12-01-avoiding-gen-ai-tools/
[best_practices]: https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- YOU MUST READ AND UNDERSTAND THE FOLLOWING ATTESTATION. -->
<!-- -->
<!-- Be aware that copying and pasting from discussion sites or generative AI isn't allowed under this DCO. -->

For the purposes of this DCO, "license" is equivalent to "license or public domain dedication," and "open source license" is equivalent to "open content license or public domain dedication."
<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
