### PR TITLE
Force reset local repo when fast-forward fails for wikijs reports

### DIFF
--- a/states/wikijs/reports_shared.sls
+++ b/states/wikijs/reports_shared.sls
@@ -101,6 +101,7 @@ include:
     - target: /srv/wikijs/sre-wiki-js
     - user: wikijs
     - fetch_tags: False
+    - force_reset: True
     - identity: /srv/wikijs/.ssh/{{ pillar.wikijs.git_ssh_key }}
     - require:
       - git: {{ sls }} set git user.email
@@ -112,6 +113,7 @@ include:
     - target: /srv/wikijs/sre-report-to-wikijs
     - user: wikijs
     - fetch_tags: False
+    - force_reset: True
     - identity: /srv/wikijs/.ssh/{{ pillar.wikijs.git_ssh_key }}
     - require:
       - git: {{ sls }} set git user.email


### PR DESCRIPTION
<!-- ⚠️ Pull requests (PRs) that don't follow this template will be discarded. -->
## Fixes

Fixes the following error:
```
          ID: wikijs.reports_shared sre-wiki-js repo
    Function: git.latest
      Result: False
     Comment: Repository would be updated to 8d0e0b7, but this is not a
              fast-forward merge. Set 'force_reset' to True to force this update.
     Started: 13:43:52.153110
    Duration: 1693.009 ms
```

## Description
Force reset local repositopry when fast-forward fails for wikijs reports

## Technical details
- [salt.states.git](https://docs.saltproject.io/en/latest/ref/states/all/salt.states.git.html#salt.states.git.latest)

## Tests
Observed successful highstate after update.

<!--
## Screenshots
<!-- Add screenshots to show the problem and the solution; or comment out this section entirely. -->

## Checklist
<!-- DON'T remove this section or any of the lines. -->
<!-- Leave incomplete or inapplicable lines unchecked. -->
<!-- Replace the [ ] with [x] to check the boxes (there is no space between x and square brackets). -->
- [x] I have read and understood the Developer Certificate of Origin (DCO), below, which covers the contents of this pull request (PR).
- [x] My pull request doesn't include code or content generated with AI (also see [Avoiding generative AI development tools — Creative Commons Open Source][no-ai]).
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated unit tests and/or test scripts for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[no-ai]: https://opensource.creativecommons.org/blog/entries/2025-12-01-avoiding-gen-ai-tools/
[best_practices]: https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- YOU MUST READ AND UNDERSTAND THE FOLLOWING ATTESTATION. -->
<!-- -->
<!-- Be aware that copying and pasting from discussion sites or generative AI isn't allowed under this DCO. -->

For the purposes of this DCO, "license" is equivalent to "license or public domain dedication," and "open source license" is equivalent to "open content license or public domain dedication."
<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
