### PR TITLE
Improve swap state and add 64G swap to index__prod__us-east-2

### DIFF
--- a/pillars/5_HST__POD/index__prod/init.sls
+++ b/pillars/5_HST__POD/index__prod/init.sls
@@ -12,6 +12,12 @@ letsencrypt:
   domainsets:
     {{ WEBNAME }}:
       - {{ WEBNAME }}
+linux:
+  # 1. r8a.medium supports 314 workers per states/apache2/mpm_prefork.sls
+  # 2. Assuming 8M per worker + PHP memory_lmit = 128M
+  # 3. ( 8 + 128 ) * 314 = 42,704
+  # 4. Rounding 42,704 up to 64,000
+  swapsize: 64000
 mysql:
   # (also see 5_HST__POD.index__prod.secrets)
   server:

--- a/pillars/5_HST__POD/index__prod/init.sls
+++ b/pillars/5_HST__POD/index__prod/init.sls
@@ -16,8 +16,9 @@ linux:
   # 1. r8a.medium supports 314 workers per states/apache2/mpm_prefork.sls
   # 2. Assuming 8M per worker + PHP memory_lmit = 128M
   # 3. ( 8 + 128 ) * 314 = 42,704
-  # 4. Rounding 42,704 up to 64,000
-  swapsize: 64000
+  # 4. Rounding 42,704 up to 64,000M
+  # 5. states/swapfile/init.sls expects G
+  swapsize: 64
 mysql:
   # (also see 5_HST__POD.index__prod.secrets)
   server:

--- a/states/swapfile/init.sls
+++ b/states/swapfile/init.sls
@@ -4,7 +4,7 @@
 
 {{ sls }} create swapfile:
   cmd.run:
-    - name: dd if=/dev/zero of=/swapfile bs=1024 count={{ SWAPSIZE }}M
+    - name: fallocate -l {{ SWAPSIZE }}G /swapfile
     - unless:
       - test -f /swapfile
 
@@ -20,9 +20,9 @@
 
 {{ sls }} activate swapfile:
   cmd.run:
-    - name: mkswap /swapfile && swapon -a
+    - name: mkswap /swapfile && swapon /swapfile
     - unless:
-      - file /swapfile 2>&1 | grep -q 'Linux/i386 swap'
+      - swapon --show=NAME | grep -q '^/swapfile'
     - require:
       - file: {{ sls }} swapfile permissions
 


### PR DESCRIPTION
## Fixes
- Fixes creativecommons/tech-support/issues/1489 (private repository)

## Description
Improve swap state and add 64G swap to `index__prod__us-east-2`
- Changes are live in production

## Technical details
- [Swap - Debian Wiki](https://wiki.debian.org/Swap)
- [fallocate(1) — util-linux — Debian trixie — Debian Manpages](https://manpages.debian.org/trixie/util-linux/fallocate.1.en.html)
- [swapon(8) — mount — Debian trixie — Debian Manpages](https://manpages.debian.org/trixie/mount/swapon.8.en.html)

## Tests
```shell
free -h
```
```
               total        used        free      shared  buff/cache   available
Mem:           7.6Gi       2.3Gi       3.9Gi        56Mi       1.4Gi       4.9Gi
Swap:           63Gi          0B        63Gi
```

<!--
## Screenshots
<!-- Add screenshots to show the problem and the solution; or comment out this section entirely. -->

## Checklist
<!-- DON'T remove this section or any of the lines. -->
<!-- Leave incomplete or inapplicable lines unchecked. -->
<!-- Replace the [ ] with [x] to check the boxes (there is no space between x and square brackets). -->
- [x] I have read and understood the Developer Certificate of Origin (DCO), below, which covers the contents of this pull request (PR).
- [x] My pull request doesn't include code or content generated with AI (also see [Avoiding generative AI development tools — Creative Commons Open Source][no-ai]).
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated unit tests and/or test scripts for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[no-ai]: https://opensource.creativecommons.org/blog/entries/2025-12-01-avoiding-gen-ai-tools/
[best_practices]: https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- YOU MUST READ AND UNDERSTAND THE FOLLOWING ATTESTATION. -->
<!-- -->
<!-- Be aware that copying and pasting from discussion sites or generative AI isn't allowed under this DCO. -->

For the purposes of this DCO, "license" is equivalent to "license or public domain dedication," and "open source license" is equivalent to "open content license or public domain dedication."
<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
