### PR TITLE
Improve reliability of reboot notice from cron

### DIFF
--- a/states/reboot_notice/files/reboot_notice.sh
+++ b/states/reboot_notice/files/reboot_notice.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/bash
+#!/bin/bash
 set -o errexit
 set -o errtrace
 set -o nounset
@@ -30,7 +30,7 @@ else
     _BODY="${_UPTIME}"
 fi
 _HOST="${HOSTNAME%%.*}"
-_FROM="From: ${USER}+${_HOST}@creativecommons.org"
+_FROM="From: root+${_HOST}@creativecommons.org"
 printf "To: root\n%s\n%s\n\n%s\n\n." "${_FROM}" "${_SUBJECT}" "${_BODY}" \
     | /usr/lib/sendmail -t
 # man sendmail excerpt:

--- a/states/reboot_notice/files/reboot_notice.sh
+++ b/states/reboot_notice/files/reboot_notice.sh
@@ -10,8 +10,8 @@ trap '_es=${?};
     echo "${0}: line ${_lo}: \"${_co}\" exited with a status of ${_es}";
     exit ${_es}' ERR
 
-_NOW="$(/usr/bin/date '+%s')"
-_UPTIME="$(/usr/bin/date --date="$(/usr/bin/uptime --since)" '+%s')"
+_NOW="$(/bin/date '+%s')"
+_UPTIME="$(/bin/date --date="$(/usr/bin/uptime --since)" '+%s')"
 _UPTIME="$(( _NOW - _UPTIME))"
 (( _UPTIME > 86340 )) && exit
 


### PR DESCRIPTION
<!-- ⚠️ Pull requests (PRs) that don't follow this template will be discarded. -->
## Fixes

Resolves the following errors:
> /bin/sh: 1: /usr/local/sbin/reboot_notice.sh: not found

> /usr/local/sbin/reboot_notice.sh: line 33: USER: unbound variable

> /usr/local/sbin/reboot_notice.sh: line 13: /usr/bin/date: No such file or directory
> /usr/local/sbin/reboot_notice.sh: line 14: "_NOW="$(/usr/bin/date '+%s')"" exited with a status of 127

## Description
Improve reliability of reboot notice from cron
- changes are live in production on all managed hosts

## Technical details
- [crontab(5) — cronie — Debian trixie — Debian Manpages](https://manpages.debian.org/trixie/cronie/crontab.5.en.html)
- [sh(1) — dash — Debian trixie — Debian Manpages](https://manpages.debian.org/trixie/dash/sh.1.en.html)
- [salt.states.file](https://docs.saltproject.io/en/3006/ref/states/all/salt.states.file.html)
- [salt.states.cron](https://docs.saltproject.io/en/3006/ref/states/all/salt.states.cron.html)

<!--
## Tests
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or comment out this section entirely. -->

<!--
## Screenshots
<!-- Add screenshots to show the problem and the solution; or comment out this section entirely. -->

## Checklist
<!-- DON'T remove this section or any of the lines. -->
<!-- Leave incomplete or inapplicable lines unchecked. -->
<!-- Replace the [ ] with [x] to check the boxes (there is no space between x and square brackets). -->
- [x] I have read and understood the Developer Certificate of Origin (DCO), below, which covers the contents of this pull request (PR).
- [x] My pull request doesn't include code or content generated with AI (also see [Avoiding generative AI development tools — Creative Commons Open Source][no-ai]).
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added or updated unit tests and/or test scripts for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[no-ai]: https://opensource.creativecommons.org/blog/entries/2025-12-01-avoiding-gen-ai-tools/
[best_practices]: https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- YOU MUST READ AND UNDERSTAND THE FOLLOWING ATTESTATION. -->
<!-- -->
<!-- Be aware that copying and pasting from discussion sites or generative AI isn't allowed under this DCO. -->

For the purposes of this DCO, "license" is equivalent to "license or public domain dedication," and "open source license" is equivalent to "open content license or public domain dedication."
<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
